### PR TITLE
chore: Migrate securitycenter synth.py to bazel

### DIFF
--- a/grpc-google-cloud-securitycenter-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-securitycenter-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.120.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/securitycenter/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-securitycenter-v1/src/main/java/com/google/cloud/securitycenter/v1/SecurityCenterGrpc.java
+++ b/grpc-google-cloud-securitycenter-v1/src/main/java/com/google/cloud/securitycenter/v1/SecurityCenterGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/securitycenter/v1/securitycenter_service.proto")
 public final class SecurityCenterGrpc {
 
@@ -39,30 +39,20 @@ public final class SecurityCenterGrpc {
   public static final String SERVICE_NAME = "google.cloud.securitycenter.v1.SecurityCenter";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.CreateSourceRequest,
-          com.google.cloud.securitycenter.v1.Source>
-      METHOD_CREATE_SOURCE = getCreateSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.CreateSourceRequest,
           com.google.cloud.securitycenter.v1.Source>
       getCreateSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateSource",
+      requestType = com.google.cloud.securitycenter.v1.CreateSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.CreateSourceRequest,
           com.google.cloud.securitycenter.v1.Source>
       getCreateSourceMethod() {
-    return getCreateSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.CreateSourceRequest,
-          com.google.cloud.securitycenter.v1.Source>
-      getCreateSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.CreateSourceRequest,
             com.google.cloud.securitycenter.v1.Source>
@@ -77,9 +67,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "CreateSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -97,30 +85,20 @@ public final class SecurityCenterGrpc {
     return getCreateSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateFindingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.CreateFindingRequest,
-          com.google.cloud.securitycenter.v1.Finding>
-      METHOD_CREATE_FINDING = getCreateFindingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.CreateFindingRequest,
           com.google.cloud.securitycenter.v1.Finding>
       getCreateFindingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateFinding",
+      requestType = com.google.cloud.securitycenter.v1.CreateFindingRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.CreateFindingRequest,
           com.google.cloud.securitycenter.v1.Finding>
       getCreateFindingMethod() {
-    return getCreateFindingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.CreateFindingRequest,
-          com.google.cloud.securitycenter.v1.Finding>
-      getCreateFindingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.CreateFindingRequest,
             com.google.cloud.securitycenter.v1.Finding>
@@ -135,9 +113,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "CreateFinding"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateFinding"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -155,30 +131,20 @@ public final class SecurityCenterGrpc {
     return getCreateFindingMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1.NotificationConfig>
-      METHOD_CREATE_NOTIFICATION_CONFIG = getCreateNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1.NotificationConfig>
       getCreateNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.NotificationConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1.NotificationConfig>
       getCreateNotificationConfigMethod() {
-    return getCreateNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1.NotificationConfig>
-      getCreateNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest,
             com.google.cloud.securitycenter.v1.NotificationConfig>
@@ -197,9 +163,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "CreateNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "CreateNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -218,30 +182,20 @@ public final class SecurityCenterGrpc {
     return getCreateNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest,
-          com.google.protobuf.Empty>
-      METHOD_DELETE_NOTIFICATION_CONFIG = getDeleteNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest,
           com.google.protobuf.Empty>
       getDeleteNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest,
           com.google.protobuf.Empty>
       getDeleteNotificationConfigMethod() {
-    return getDeleteNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest,
-          com.google.protobuf.Empty>
-      getDeleteNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest,
             com.google.protobuf.Empty>
@@ -260,9 +214,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "DeleteNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -280,26 +232,18 @@ public final class SecurityCenterGrpc {
     return getDeleteNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = SecurityCenterGrpc.getGetIamPolicyMethod) == null) {
@@ -310,9 +254,7 @@ public final class SecurityCenterGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -329,30 +271,20 @@ public final class SecurityCenterGrpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GetNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1.NotificationConfig>
-      METHOD_GET_NOTIFICATION_CONFIG = getGetNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GetNotificationConfigRequest,
           com.google.cloud.securitycenter.v1.NotificationConfig>
       getGetNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1.GetNotificationConfigRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.NotificationConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GetNotificationConfigRequest,
           com.google.cloud.securitycenter.v1.NotificationConfig>
       getGetNotificationConfigMethod() {
-    return getGetNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GetNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1.NotificationConfig>
-      getGetNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.GetNotificationConfigRequest,
             com.google.cloud.securitycenter.v1.NotificationConfig>
@@ -370,9 +302,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "GetNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "GetNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -391,30 +321,20 @@ public final class SecurityCenterGrpc {
     return getGetNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetOrganizationSettingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1.OrganizationSettings>
-      METHOD_GET_ORGANIZATION_SETTINGS = getGetOrganizationSettingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1.OrganizationSettings>
       getGetOrganizationSettingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetOrganizationSettings",
+      requestType = com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.OrganizationSettings.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1.OrganizationSettings>
       getGetOrganizationSettingsMethod() {
-    return getGetOrganizationSettingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1.OrganizationSettings>
-      getGetOrganizationSettingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest,
             com.google.cloud.securitycenter.v1.OrganizationSettings>
@@ -432,9 +352,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "GetOrganizationSettings"))
+                          generateFullMethodName(SERVICE_NAME, "GetOrganizationSettings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -453,30 +371,20 @@ public final class SecurityCenterGrpc {
     return getGetOrganizationSettingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GetSourceRequest,
-          com.google.cloud.securitycenter.v1.Source>
-      METHOD_GET_SOURCE = getGetSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GetSourceRequest,
           com.google.cloud.securitycenter.v1.Source>
       getGetSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetSource",
+      requestType = com.google.cloud.securitycenter.v1.GetSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GetSourceRequest,
           com.google.cloud.securitycenter.v1.Source>
       getGetSourceMethod() {
-    return getGetSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GetSourceRequest,
-          com.google.cloud.securitycenter.v1.Source>
-      getGetSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.GetSourceRequest,
             com.google.cloud.securitycenter.v1.Source>
@@ -491,9 +399,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "GetSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -510,30 +416,20 @@ public final class SecurityCenterGrpc {
     return getGetSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGroupAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GroupAssetsRequest,
-          com.google.cloud.securitycenter.v1.GroupAssetsResponse>
-      METHOD_GROUP_ASSETS = getGroupAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GroupAssetsRequest,
           com.google.cloud.securitycenter.v1.GroupAssetsResponse>
       getGroupAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GroupAssets",
+      requestType = com.google.cloud.securitycenter.v1.GroupAssetsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.GroupAssetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GroupAssetsRequest,
           com.google.cloud.securitycenter.v1.GroupAssetsResponse>
       getGroupAssetsMethod() {
-    return getGroupAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GroupAssetsRequest,
-          com.google.cloud.securitycenter.v1.GroupAssetsResponse>
-      getGroupAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.GroupAssetsRequest,
             com.google.cloud.securitycenter.v1.GroupAssetsResponse>
@@ -548,9 +444,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.GroupAssetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "GroupAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GroupAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -569,30 +463,20 @@ public final class SecurityCenterGrpc {
     return getGroupAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGroupFindingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GroupFindingsRequest,
-          com.google.cloud.securitycenter.v1.GroupFindingsResponse>
-      METHOD_GROUP_FINDINGS = getGroupFindingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GroupFindingsRequest,
           com.google.cloud.securitycenter.v1.GroupFindingsResponse>
       getGroupFindingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GroupFindings",
+      requestType = com.google.cloud.securitycenter.v1.GroupFindingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.GroupFindingsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.GroupFindingsRequest,
           com.google.cloud.securitycenter.v1.GroupFindingsResponse>
       getGroupFindingsMethod() {
-    return getGroupFindingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.GroupFindingsRequest,
-          com.google.cloud.securitycenter.v1.GroupFindingsResponse>
-      getGroupFindingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.GroupFindingsRequest,
             com.google.cloud.securitycenter.v1.GroupFindingsResponse>
@@ -607,9 +491,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.GroupFindingsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "GroupFindings"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GroupFindings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -628,30 +510,20 @@ public final class SecurityCenterGrpc {
     return getGroupFindingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListAssetsRequest,
-          com.google.cloud.securitycenter.v1.ListAssetsResponse>
-      METHOD_LIST_ASSETS = getListAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListAssetsRequest,
           com.google.cloud.securitycenter.v1.ListAssetsResponse>
       getListAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListAssets",
+      requestType = com.google.cloud.securitycenter.v1.ListAssetsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.ListAssetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListAssetsRequest,
           com.google.cloud.securitycenter.v1.ListAssetsResponse>
       getListAssetsMethod() {
-    return getListAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListAssetsRequest,
-          com.google.cloud.securitycenter.v1.ListAssetsResponse>
-      getListAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.ListAssetsRequest,
             com.google.cloud.securitycenter.v1.ListAssetsResponse>
@@ -666,9 +538,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.ListAssetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "ListAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -686,30 +556,20 @@ public final class SecurityCenterGrpc {
     return getListAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListFindingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListFindingsRequest,
-          com.google.cloud.securitycenter.v1.ListFindingsResponse>
-      METHOD_LIST_FINDINGS = getListFindingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListFindingsRequest,
           com.google.cloud.securitycenter.v1.ListFindingsResponse>
       getListFindingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListFindings",
+      requestType = com.google.cloud.securitycenter.v1.ListFindingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.ListFindingsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListFindingsRequest,
           com.google.cloud.securitycenter.v1.ListFindingsResponse>
       getListFindingsMethod() {
-    return getListFindingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListFindingsRequest,
-          com.google.cloud.securitycenter.v1.ListFindingsResponse>
-      getListFindingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.ListFindingsRequest,
             com.google.cloud.securitycenter.v1.ListFindingsResponse>
@@ -724,9 +584,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.ListFindingsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "ListFindings"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListFindings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -745,30 +603,20 @@ public final class SecurityCenterGrpc {
     return getListFindingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListNotificationConfigsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest,
-          com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
-      METHOD_LIST_NOTIFICATION_CONFIGS = getListNotificationConfigsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest,
           com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
       getListNotificationConfigsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListNotificationConfigs",
+      requestType = com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest,
           com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
       getListNotificationConfigsMethod() {
-    return getListNotificationConfigsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest,
-          com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
-      getListNotificationConfigsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest,
             com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
@@ -786,9 +634,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "ListNotificationConfigs"))
+                          generateFullMethodName(SERVICE_NAME, "ListNotificationConfigs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -807,30 +653,20 @@ public final class SecurityCenterGrpc {
     return getListNotificationConfigsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListSourcesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListSourcesRequest,
-          com.google.cloud.securitycenter.v1.ListSourcesResponse>
-      METHOD_LIST_SOURCES = getListSourcesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListSourcesRequest,
           com.google.cloud.securitycenter.v1.ListSourcesResponse>
       getListSourcesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListSources",
+      requestType = com.google.cloud.securitycenter.v1.ListSourcesRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.ListSourcesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.ListSourcesRequest,
           com.google.cloud.securitycenter.v1.ListSourcesResponse>
       getListSourcesMethod() {
-    return getListSourcesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.ListSourcesRequest,
-          com.google.cloud.securitycenter.v1.ListSourcesResponse>
-      getListSourcesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.ListSourcesRequest,
             com.google.cloud.securitycenter.v1.ListSourcesResponse>
@@ -845,9 +681,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.ListSourcesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "ListSources"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListSources"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -866,30 +700,20 @@ public final class SecurityCenterGrpc {
     return getListSourcesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRunAssetDiscoveryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest,
-          com.google.longrunning.Operation>
-      METHOD_RUN_ASSET_DISCOVERY = getRunAssetDiscoveryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest,
           com.google.longrunning.Operation>
       getRunAssetDiscoveryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RunAssetDiscovery",
+      requestType = com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest,
           com.google.longrunning.Operation>
       getRunAssetDiscoveryMethod() {
-    return getRunAssetDiscoveryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest,
-          com.google.longrunning.Operation>
-      getRunAssetDiscoveryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest,
             com.google.longrunning.Operation>
@@ -904,9 +728,7 @@ public final class SecurityCenterGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "RunAssetDiscovery"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "RunAssetDiscovery"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -924,30 +746,20 @@ public final class SecurityCenterGrpc {
     return getRunAssetDiscoveryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetFindingStateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.SetFindingStateRequest,
-          com.google.cloud.securitycenter.v1.Finding>
-      METHOD_SET_FINDING_STATE = getSetFindingStateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.SetFindingStateRequest,
           com.google.cloud.securitycenter.v1.Finding>
       getSetFindingStateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetFindingState",
+      requestType = com.google.cloud.securitycenter.v1.SetFindingStateRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.SetFindingStateRequest,
           com.google.cloud.securitycenter.v1.Finding>
       getSetFindingStateMethod() {
-    return getSetFindingStateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.SetFindingStateRequest,
-          com.google.cloud.securitycenter.v1.Finding>
-      getSetFindingStateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.SetFindingStateRequest,
             com.google.cloud.securitycenter.v1.Finding>
@@ -962,9 +774,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "SetFindingState"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetFindingState"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -982,26 +792,18 @@ public final class SecurityCenterGrpc {
     return getSetFindingStateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = SecurityCenterGrpc.getSetIamPolicyMethod) == null) {
@@ -1012,9 +814,7 @@ public final class SecurityCenterGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1031,26 +831,18 @@ public final class SecurityCenterGrpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -1066,10 +858,7 @@ public final class SecurityCenterGrpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1086,30 +875,20 @@ public final class SecurityCenterGrpc {
     return getTestIamPermissionsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateFindingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateFindingRequest,
-          com.google.cloud.securitycenter.v1.Finding>
-      METHOD_UPDATE_FINDING = getUpdateFindingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateFindingRequest,
           com.google.cloud.securitycenter.v1.Finding>
       getUpdateFindingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateFinding",
+      requestType = com.google.cloud.securitycenter.v1.UpdateFindingRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateFindingRequest,
           com.google.cloud.securitycenter.v1.Finding>
       getUpdateFindingMethod() {
-    return getUpdateFindingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateFindingRequest,
-          com.google.cloud.securitycenter.v1.Finding>
-      getUpdateFindingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.UpdateFindingRequest,
             com.google.cloud.securitycenter.v1.Finding>
@@ -1124,9 +903,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "UpdateFinding"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateFinding"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1144,30 +921,20 @@ public final class SecurityCenterGrpc {
     return getUpdateFindingMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1.NotificationConfig>
-      METHOD_UPDATE_NOTIFICATION_CONFIG = getUpdateNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1.NotificationConfig>
       getUpdateNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.NotificationConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1.NotificationConfig>
       getUpdateNotificationConfigMethod() {
-    return getUpdateNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1.NotificationConfig>
-      getUpdateNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest,
             com.google.cloud.securitycenter.v1.NotificationConfig>
@@ -1186,9 +953,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "UpdateNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1207,30 +972,20 @@ public final class SecurityCenterGrpc {
     return getUpdateNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateOrganizationSettingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1.OrganizationSettings>
-      METHOD_UPDATE_ORGANIZATION_SETTINGS = getUpdateOrganizationSettingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1.OrganizationSettings>
       getUpdateOrganizationSettingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateOrganizationSettings",
+      requestType = com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.OrganizationSettings.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1.OrganizationSettings>
       getUpdateOrganizationSettingsMethod() {
-    return getUpdateOrganizationSettingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1.OrganizationSettings>
-      getUpdateOrganizationSettingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest,
             com.google.cloud.securitycenter.v1.OrganizationSettings>
@@ -1250,9 +1005,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "UpdateOrganizationSettings"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateOrganizationSettings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1271,30 +1024,20 @@ public final class SecurityCenterGrpc {
     return getUpdateOrganizationSettingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateSourceRequest,
-          com.google.cloud.securitycenter.v1.Source>
-      METHOD_UPDATE_SOURCE = getUpdateSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateSourceRequest,
           com.google.cloud.securitycenter.v1.Source>
       getUpdateSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSource",
+      requestType = com.google.cloud.securitycenter.v1.UpdateSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateSourceRequest,
           com.google.cloud.securitycenter.v1.Source>
       getUpdateSourceMethod() {
-    return getUpdateSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateSourceRequest,
-          com.google.cloud.securitycenter.v1.Source>
-      getUpdateSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.UpdateSourceRequest,
             com.google.cloud.securitycenter.v1.Source>
@@ -1309,9 +1052,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter", "UpdateSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1329,30 +1070,20 @@ public final class SecurityCenterGrpc {
     return getUpdateSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSecurityMarksMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest,
-          com.google.cloud.securitycenter.v1.SecurityMarks>
-      METHOD_UPDATE_SECURITY_MARKS = getUpdateSecurityMarksMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest,
           com.google.cloud.securitycenter.v1.SecurityMarks>
       getUpdateSecurityMarksMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSecurityMarks",
+      requestType = com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest.class,
+      responseType = com.google.cloud.securitycenter.v1.SecurityMarks.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest,
           com.google.cloud.securitycenter.v1.SecurityMarks>
       getUpdateSecurityMarksMethod() {
-    return getUpdateSecurityMarksMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest,
-          com.google.cloud.securitycenter.v1.SecurityMarks>
-      getUpdateSecurityMarksMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest,
             com.google.cloud.securitycenter.v1.SecurityMarks>
@@ -1369,9 +1100,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1.SecurityCenter",
-                              "UpdateSecurityMarks"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateSecurityMarks"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1392,19 +1121,43 @@ public final class SecurityCenterGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SecurityCenterStub newStub(io.grpc.Channel channel) {
-    return new SecurityCenterStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterStub>() {
+          @java.lang.Override
+          public SecurityCenterStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SecurityCenterBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SecurityCenterBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterBlockingStub>() {
+          @java.lang.Override
+          public SecurityCenterBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterBlockingStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SecurityCenterFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SecurityCenterFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterFutureStub>() {
+          @java.lang.Override
+          public SecurityCenterFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterFutureStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1426,7 +1179,7 @@ public final class SecurityCenterGrpc {
     public void createSource(
         com.google.cloud.securitycenter.v1.CreateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Source> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateSourceMethod(), responseObserver);
     }
 
     /**
@@ -1440,7 +1193,7 @@ public final class SecurityCenterGrpc {
     public void createFinding(
         com.google.cloud.securitycenter.v1.CreateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Finding> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateFindingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateFindingMethod(), responseObserver);
     }
 
     /**
@@ -1454,7 +1207,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.NotificationConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1467,7 +1220,7 @@ public final class SecurityCenterGrpc {
     public void deleteNotificationConfig(
         com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1480,7 +1233,7 @@ public final class SecurityCenterGrpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -1494,7 +1247,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.GetNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.NotificationConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1508,7 +1261,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.OrganizationSettings>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetOrganizationSettingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetOrganizationSettingsMethod(), responseObserver);
     }
 
     /**
@@ -1521,7 +1274,7 @@ public final class SecurityCenterGrpc {
     public void getSource(
         com.google.cloud.securitycenter.v1.GetSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Source> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetSourceMethod(), responseObserver);
     }
 
     /**
@@ -1536,7 +1289,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.GroupAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.GroupAssetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGroupAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGroupAssetsMethod(), responseObserver);
     }
 
     /**
@@ -1553,7 +1306,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.GroupFindingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.GroupFindingsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGroupFindingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGroupFindingsMethod(), responseObserver);
     }
 
     /**
@@ -1567,7 +1320,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.ListAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.ListAssetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListAssetsMethod(), responseObserver);
     }
 
     /**
@@ -1583,7 +1336,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.ListFindingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.ListFindingsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListFindingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListFindingsMethod(), responseObserver);
     }
 
     /**
@@ -1598,7 +1351,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListNotificationConfigsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListNotificationConfigsMethod(), responseObserver);
     }
 
     /**
@@ -1612,7 +1365,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.ListSourcesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.ListSourcesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListSourcesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListSourcesMethod(), responseObserver);
     }
 
     /**
@@ -1629,7 +1382,7 @@ public final class SecurityCenterGrpc {
     public void runAssetDiscovery(
         com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getRunAssetDiscoveryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRunAssetDiscoveryMethod(), responseObserver);
     }
 
     /**
@@ -1642,7 +1395,7 @@ public final class SecurityCenterGrpc {
     public void setFindingState(
         com.google.cloud.securitycenter.v1.SetFindingStateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Finding> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetFindingStateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetFindingStateMethod(), responseObserver);
     }
 
     /**
@@ -1655,7 +1408,7 @@ public final class SecurityCenterGrpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -1669,7 +1422,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     /**
@@ -1683,7 +1436,7 @@ public final class SecurityCenterGrpc {
     public void updateFinding(
         com.google.cloud.securitycenter.v1.UpdateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Finding> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateFindingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateFindingMethod(), responseObserver);
     }
 
     /**
@@ -1697,7 +1450,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.NotificationConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1711,7 +1464,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.OrganizationSettings>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateOrganizationSettingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateOrganizationSettingsMethod(), responseObserver);
     }
 
     /**
@@ -1724,7 +1477,7 @@ public final class SecurityCenterGrpc {
     public void updateSource(
         com.google.cloud.securitycenter.v1.UpdateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Source> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSourceMethod(), responseObserver);
     }
 
     /**
@@ -1738,159 +1491,159 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.SecurityMarks>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSecurityMarksMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSecurityMarksMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateSourceMethodHelper(),
+              getCreateSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.CreateSourceRequest,
                       com.google.cloud.securitycenter.v1.Source>(this, METHODID_CREATE_SOURCE)))
           .addMethod(
-              getCreateFindingMethodHelper(),
+              getCreateFindingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.CreateFindingRequest,
                       com.google.cloud.securitycenter.v1.Finding>(this, METHODID_CREATE_FINDING)))
           .addMethod(
-              getCreateNotificationConfigMethodHelper(),
+              getCreateNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest,
                       com.google.cloud.securitycenter.v1.NotificationConfig>(
                       this, METHODID_CREATE_NOTIFICATION_CONFIG)))
           .addMethod(
-              getDeleteNotificationConfigMethodHelper(),
+              getDeleteNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_NOTIFICATION_CONFIG)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getGetNotificationConfigMethodHelper(),
+              getGetNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.GetNotificationConfigRequest,
                       com.google.cloud.securitycenter.v1.NotificationConfig>(
                       this, METHODID_GET_NOTIFICATION_CONFIG)))
           .addMethod(
-              getGetOrganizationSettingsMethodHelper(),
+              getGetOrganizationSettingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest,
                       com.google.cloud.securitycenter.v1.OrganizationSettings>(
                       this, METHODID_GET_ORGANIZATION_SETTINGS)))
           .addMethod(
-              getGetSourceMethodHelper(),
+              getGetSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.GetSourceRequest,
                       com.google.cloud.securitycenter.v1.Source>(this, METHODID_GET_SOURCE)))
           .addMethod(
-              getGroupAssetsMethodHelper(),
+              getGroupAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.GroupAssetsRequest,
                       com.google.cloud.securitycenter.v1.GroupAssetsResponse>(
                       this, METHODID_GROUP_ASSETS)))
           .addMethod(
-              getGroupFindingsMethodHelper(),
+              getGroupFindingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.GroupFindingsRequest,
                       com.google.cloud.securitycenter.v1.GroupFindingsResponse>(
                       this, METHODID_GROUP_FINDINGS)))
           .addMethod(
-              getListAssetsMethodHelper(),
+              getListAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.ListAssetsRequest,
                       com.google.cloud.securitycenter.v1.ListAssetsResponse>(
                       this, METHODID_LIST_ASSETS)))
           .addMethod(
-              getListFindingsMethodHelper(),
+              getListFindingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.ListFindingsRequest,
                       com.google.cloud.securitycenter.v1.ListFindingsResponse>(
                       this, METHODID_LIST_FINDINGS)))
           .addMethod(
-              getListNotificationConfigsMethodHelper(),
+              getListNotificationConfigsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest,
                       com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>(
                       this, METHODID_LIST_NOTIFICATION_CONFIGS)))
           .addMethod(
-              getListSourcesMethodHelper(),
+              getListSourcesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.ListSourcesRequest,
                       com.google.cloud.securitycenter.v1.ListSourcesResponse>(
                       this, METHODID_LIST_SOURCES)))
           .addMethod(
-              getRunAssetDiscoveryMethodHelper(),
+              getRunAssetDiscoveryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest,
                       com.google.longrunning.Operation>(this, METHODID_RUN_ASSET_DISCOVERY)))
           .addMethod(
-              getSetFindingStateMethodHelper(),
+              getSetFindingStateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.SetFindingStateRequest,
                       com.google.cloud.securitycenter.v1.Finding>(
                       this, METHODID_SET_FINDING_STATE)))
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
                       com.google.iam.v1.TestIamPermissionsResponse>(
                       this, METHODID_TEST_IAM_PERMISSIONS)))
           .addMethod(
-              getUpdateFindingMethodHelper(),
+              getUpdateFindingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.UpdateFindingRequest,
                       com.google.cloud.securitycenter.v1.Finding>(this, METHODID_UPDATE_FINDING)))
           .addMethod(
-              getUpdateNotificationConfigMethodHelper(),
+              getUpdateNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest,
                       com.google.cloud.securitycenter.v1.NotificationConfig>(
                       this, METHODID_UPDATE_NOTIFICATION_CONFIG)))
           .addMethod(
-              getUpdateOrganizationSettingsMethodHelper(),
+              getUpdateOrganizationSettingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest,
                       com.google.cloud.securitycenter.v1.OrganizationSettings>(
                       this, METHODID_UPDATE_ORGANIZATION_SETTINGS)))
           .addMethod(
-              getUpdateSourceMethodHelper(),
+              getUpdateSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.UpdateSourceRequest,
                       com.google.cloud.securitycenter.v1.Source>(this, METHODID_UPDATE_SOURCE)))
           .addMethod(
-              getUpdateSecurityMarksMethodHelper(),
+              getUpdateSecurityMarksMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest,
@@ -1908,11 +1661,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterStub> {
-    private SecurityCenterStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<SecurityCenterStub> {
     private SecurityCenterStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1933,7 +1682,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.CreateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Source> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateSourceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateSourceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1950,7 +1699,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.CreateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Finding> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateFindingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateFindingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1967,7 +1716,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.NotificationConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1983,7 +1732,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1999,7 +1748,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2016,7 +1765,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.NotificationConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2033,7 +1782,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.OrganizationSettings>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetOrganizationSettingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetOrganizationSettingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2049,9 +1798,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.GetSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Source> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetSourceMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetSourceMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2067,7 +1814,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.GroupAssetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGroupAssetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGroupAssetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2087,7 +1834,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.GroupFindingsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGroupFindingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGroupFindingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2104,9 +1851,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.ListAssetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListAssetsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListAssetsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2123,7 +1868,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.ListFindingsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListFindingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListFindingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2141,7 +1886,7 @@ public final class SecurityCenterGrpc {
                 com.google.cloud.securitycenter.v1.ListNotificationConfigsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListNotificationConfigsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListNotificationConfigsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2158,7 +1903,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.ListSourcesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListSourcesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListSourcesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2178,7 +1923,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRunAssetDiscoveryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRunAssetDiscoveryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2194,7 +1939,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.SetFindingStateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Finding> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetFindingStateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetFindingStateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2210,7 +1955,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2227,7 +1972,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2244,7 +1989,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.UpdateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Finding> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateFindingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateFindingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2261,7 +2006,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.NotificationConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2278,7 +2023,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.OrganizationSettings>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateOrganizationSettingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateOrganizationSettingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2294,7 +2039,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1.UpdateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.Source> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSourceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSourceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2311,7 +2056,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1.SecurityMarks>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSecurityMarksMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSecurityMarksMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2325,11 +2070,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterBlockingStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterBlockingStub> {
-    private SecurityCenterBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SecurityCenterBlockingStub> {
     private SecurityCenterBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2349,8 +2090,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.Source createSource(
         com.google.cloud.securitycenter.v1.CreateSourceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2363,8 +2103,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.Finding createFinding(
         com.google.cloud.securitycenter.v1.CreateFindingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateFindingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateFindingMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2377,7 +2116,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1.NotificationConfig createNotificationConfig(
         com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2390,7 +2129,7 @@ public final class SecurityCenterGrpc {
     public com.google.protobuf.Empty deleteNotificationConfig(
         com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2401,8 +2140,7 @@ public final class SecurityCenterGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2415,7 +2153,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1.NotificationConfig getNotificationConfig(
         com.google.cloud.securitycenter.v1.GetNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2428,7 +2166,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1.OrganizationSettings getOrganizationSettings(
         com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetOrganizationSettingsMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetOrganizationSettingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2440,7 +2178,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.Source getSource(
         com.google.cloud.securitycenter.v1.GetSourceRequest request) {
-      return blockingUnaryCall(getChannel(), getGetSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2453,8 +2191,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.GroupAssetsResponse groupAssets(
         com.google.cloud.securitycenter.v1.GroupAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGroupAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGroupAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2469,8 +2206,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.GroupFindingsResponse groupFindings(
         com.google.cloud.securitycenter.v1.GroupFindingsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGroupFindingsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGroupFindingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2482,8 +2218,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.ListAssetsResponse listAssets(
         com.google.cloud.securitycenter.v1.ListAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2497,8 +2232,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.ListFindingsResponse listFindings(
         com.google.cloud.securitycenter.v1.ListFindingsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListFindingsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListFindingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2512,7 +2246,7 @@ public final class SecurityCenterGrpc {
         listNotificationConfigs(
             com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListNotificationConfigsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListNotificationConfigsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2524,8 +2258,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.ListSourcesResponse listSources(
         com.google.cloud.securitycenter.v1.ListSourcesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListSourcesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListSourcesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2542,7 +2275,7 @@ public final class SecurityCenterGrpc {
     public com.google.longrunning.Operation runAssetDiscovery(
         com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRunAssetDiscoveryMethodHelper(), getCallOptions(), request);
+          getChannel(), getRunAssetDiscoveryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2554,8 +2287,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.Finding setFindingState(
         com.google.cloud.securitycenter.v1.SetFindingStateRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetFindingStateMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetFindingStateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2566,8 +2298,7 @@ public final class SecurityCenterGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2580,7 +2311,7 @@ public final class SecurityCenterGrpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2593,8 +2324,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.Finding updateFinding(
         com.google.cloud.securitycenter.v1.UpdateFindingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateFindingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateFindingMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2607,7 +2337,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1.NotificationConfig updateNotificationConfig(
         com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2620,7 +2350,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1.OrganizationSettings updateOrganizationSettings(
         com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateOrganizationSettingsMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateOrganizationSettingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2632,8 +2362,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1.Source updateSource(
         com.google.cloud.securitycenter.v1.UpdateSourceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2646,7 +2375,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1.SecurityMarks updateSecurityMarks(
         com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateSecurityMarksMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateSecurityMarksMethod(), getCallOptions(), request);
     }
   }
 
@@ -2658,11 +2387,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterFutureStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterFutureStub> {
-    private SecurityCenterFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SecurityCenterFutureStub> {
     private SecurityCenterFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2684,7 +2409,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.Source>
         createSource(com.google.cloud.securitycenter.v1.CreateSourceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateSourceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2699,7 +2424,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.Finding>
         createFinding(com.google.cloud.securitycenter.v1.CreateFindingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateFindingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateFindingMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2714,8 +2439,7 @@ public final class SecurityCenterGrpc {
         createNotificationConfig(
             com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateNotificationConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2729,8 +2453,7 @@ public final class SecurityCenterGrpc {
         deleteNotificationConfig(
             com.google.cloud.securitycenter.v1.DeleteNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteNotificationConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2743,7 +2466,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2758,7 +2481,7 @@ public final class SecurityCenterGrpc {
         getNotificationConfig(
             com.google.cloud.securitycenter.v1.GetNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetNotificationConfigMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2773,8 +2496,7 @@ public final class SecurityCenterGrpc {
         getOrganizationSettings(
             com.google.cloud.securitycenter.v1.GetOrganizationSettingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetOrganizationSettingsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getGetOrganizationSettingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2787,8 +2509,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.securitycenter.v1.Source>
         getSource(com.google.cloud.securitycenter.v1.GetSourceRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetSourceMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2803,7 +2524,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.GroupAssetsResponse>
         groupAssets(com.google.cloud.securitycenter.v1.GroupAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGroupAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGroupAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2820,7 +2541,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.GroupFindingsResponse>
         groupFindings(com.google.cloud.securitycenter.v1.GroupFindingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGroupFindingsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGroupFindingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2834,7 +2555,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.ListAssetsResponse>
         listAssets(com.google.cloud.securitycenter.v1.ListAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2850,7 +2571,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.ListFindingsResponse>
         listFindings(com.google.cloud.securitycenter.v1.ListFindingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListFindingsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListFindingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2865,8 +2586,7 @@ public final class SecurityCenterGrpc {
         listNotificationConfigs(
             com.google.cloud.securitycenter.v1.ListNotificationConfigsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListNotificationConfigsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListNotificationConfigsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2880,7 +2600,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.ListSourcesResponse>
         listSources(com.google.cloud.securitycenter.v1.ListSourcesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListSourcesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListSourcesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2897,7 +2617,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         runAssetDiscovery(com.google.cloud.securitycenter.v1.RunAssetDiscoveryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRunAssetDiscoveryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getRunAssetDiscoveryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2911,7 +2631,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.Finding>
         setFindingState(com.google.cloud.securitycenter.v1.SetFindingStateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetFindingStateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetFindingStateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2924,7 +2644,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2938,7 +2658,7 @@ public final class SecurityCenterGrpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2953,7 +2673,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.Finding>
         updateFinding(com.google.cloud.securitycenter.v1.UpdateFindingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateFindingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateFindingMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2968,8 +2688,7 @@ public final class SecurityCenterGrpc {
         updateNotificationConfig(
             com.google.cloud.securitycenter.v1.UpdateNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateNotificationConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2984,8 +2703,7 @@ public final class SecurityCenterGrpc {
         updateOrganizationSettings(
             com.google.cloud.securitycenter.v1.UpdateOrganizationSettingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateOrganizationSettingsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateOrganizationSettingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2999,7 +2717,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.Source>
         updateSource(com.google.cloud.securitycenter.v1.UpdateSourceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSourceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3013,7 +2731,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1.SecurityMarks>
         updateSecurityMarks(com.google.cloud.securitycenter.v1.UpdateSecurityMarksRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSecurityMarksMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateSecurityMarksMethod(), getCallOptions()), request);
     }
   }
 
@@ -3258,29 +2976,29 @@ public final class SecurityCenterGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SecurityCenterFileDescriptorSupplier())
-                      .addMethod(getCreateSourceMethodHelper())
-                      .addMethod(getCreateFindingMethodHelper())
-                      .addMethod(getCreateNotificationConfigMethodHelper())
-                      .addMethod(getDeleteNotificationConfigMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getGetNotificationConfigMethodHelper())
-                      .addMethod(getGetOrganizationSettingsMethodHelper())
-                      .addMethod(getGetSourceMethodHelper())
-                      .addMethod(getGroupAssetsMethodHelper())
-                      .addMethod(getGroupFindingsMethodHelper())
-                      .addMethod(getListAssetsMethodHelper())
-                      .addMethod(getListFindingsMethodHelper())
-                      .addMethod(getListNotificationConfigsMethodHelper())
-                      .addMethod(getListSourcesMethodHelper())
-                      .addMethod(getRunAssetDiscoveryMethodHelper())
-                      .addMethod(getSetFindingStateMethodHelper())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
-                      .addMethod(getUpdateFindingMethodHelper())
-                      .addMethod(getUpdateNotificationConfigMethodHelper())
-                      .addMethod(getUpdateOrganizationSettingsMethodHelper())
-                      .addMethod(getUpdateSourceMethodHelper())
-                      .addMethod(getUpdateSecurityMarksMethodHelper())
+                      .addMethod(getCreateSourceMethod())
+                      .addMethod(getCreateFindingMethod())
+                      .addMethod(getCreateNotificationConfigMethod())
+                      .addMethod(getDeleteNotificationConfigMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getGetNotificationConfigMethod())
+                      .addMethod(getGetOrganizationSettingsMethod())
+                      .addMethod(getGetSourceMethod())
+                      .addMethod(getGroupAssetsMethod())
+                      .addMethod(getGroupFindingsMethod())
+                      .addMethod(getListAssetsMethod())
+                      .addMethod(getListFindingsMethod())
+                      .addMethod(getListNotificationConfigsMethod())
+                      .addMethod(getListSourcesMethod())
+                      .addMethod(getRunAssetDiscoveryMethod())
+                      .addMethod(getSetFindingStateMethod())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
+                      .addMethod(getUpdateFindingMethod())
+                      .addMethod(getUpdateNotificationConfigMethod())
+                      .addMethod(getUpdateOrganizationSettingsMethod())
+                      .addMethod(getUpdateSourceMethod())
+                      .addMethod(getUpdateSecurityMarksMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-securitycenter-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-securitycenter-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.120.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/securitycenter/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/SecurityCenterGrpc.java
+++ b/grpc-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/SecurityCenterGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/securitycenter/v1beta1/securitycenter_service.proto")
 public final class SecurityCenterGrpc {
 
@@ -39,30 +39,20 @@ public final class SecurityCenterGrpc {
   public static final String SERVICE_NAME = "google.cloud.securitycenter.v1beta1.SecurityCenter";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.CreateSourceRequest,
-          com.google.cloud.securitycenter.v1beta1.Source>
-      METHOD_CREATE_SOURCE = getCreateSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.CreateSourceRequest,
           com.google.cloud.securitycenter.v1beta1.Source>
       getCreateSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateSource",
+      requestType = com.google.cloud.securitycenter.v1beta1.CreateSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.CreateSourceRequest,
           com.google.cloud.securitycenter.v1beta1.Source>
       getCreateSourceMethod() {
-    return getCreateSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.CreateSourceRequest,
-          com.google.cloud.securitycenter.v1beta1.Source>
-      getCreateSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.CreateSourceRequest,
             com.google.cloud.securitycenter.v1beta1.Source>
@@ -77,9 +67,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "CreateSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -97,30 +85,20 @@ public final class SecurityCenterGrpc {
     return getCreateSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateFindingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.CreateFindingRequest,
-          com.google.cloud.securitycenter.v1beta1.Finding>
-      METHOD_CREATE_FINDING = getCreateFindingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.CreateFindingRequest,
           com.google.cloud.securitycenter.v1beta1.Finding>
       getCreateFindingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateFinding",
+      requestType = com.google.cloud.securitycenter.v1beta1.CreateFindingRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.CreateFindingRequest,
           com.google.cloud.securitycenter.v1beta1.Finding>
       getCreateFindingMethod() {
-    return getCreateFindingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.CreateFindingRequest,
-          com.google.cloud.securitycenter.v1beta1.Finding>
-      getCreateFindingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.CreateFindingRequest,
             com.google.cloud.securitycenter.v1beta1.Finding>
@@ -135,10 +113,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "CreateFinding"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateFinding"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -156,26 +131,18 @@ public final class SecurityCenterGrpc {
     return getCreateFindingMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = SecurityCenterGrpc.getGetIamPolicyMethod) == null) {
@@ -186,9 +153,7 @@ public final class SecurityCenterGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -205,30 +170,20 @@ public final class SecurityCenterGrpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetOrganizationSettingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
-      METHOD_GET_ORGANIZATION_SETTINGS = getGetOrganizationSettingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
       getGetOrganizationSettingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetOrganizationSettings",
+      requestType = com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.OrganizationSettings.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
       getGetOrganizationSettingsMethod() {
-    return getGetOrganizationSettingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
-      getGetOrganizationSettingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest,
             com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
@@ -246,9 +201,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "GetOrganizationSettings"))
+                          generateFullMethodName(SERVICE_NAME, "GetOrganizationSettings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -267,30 +220,20 @@ public final class SecurityCenterGrpc {
     return getGetOrganizationSettingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GetSourceRequest,
-          com.google.cloud.securitycenter.v1beta1.Source>
-      METHOD_GET_SOURCE = getGetSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GetSourceRequest,
           com.google.cloud.securitycenter.v1beta1.Source>
       getGetSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetSource",
+      requestType = com.google.cloud.securitycenter.v1beta1.GetSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GetSourceRequest,
           com.google.cloud.securitycenter.v1beta1.Source>
       getGetSourceMethod() {
-    return getGetSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GetSourceRequest,
-          com.google.cloud.securitycenter.v1beta1.Source>
-      getGetSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.GetSourceRequest,
             com.google.cloud.securitycenter.v1beta1.Source>
@@ -305,9 +248,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "GetSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -324,30 +265,20 @@ public final class SecurityCenterGrpc {
     return getGetSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGroupAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest,
-          com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
-      METHOD_GROUP_ASSETS = getGroupAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest,
           com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
       getGroupAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GroupAssets",
+      requestType = com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest,
           com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
       getGroupAssetsMethod() {
-    return getGroupAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest,
-          com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
-      getGroupAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest,
             com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
@@ -362,9 +293,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "GroupAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GroupAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -383,30 +312,20 @@ public final class SecurityCenterGrpc {
     return getGroupAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGroupFindingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest,
-          com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
-      METHOD_GROUP_FINDINGS = getGroupFindingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest,
           com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
       getGroupFindingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GroupFindings",
+      requestType = com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest,
           com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
       getGroupFindingsMethod() {
-    return getGroupFindingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest,
-          com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
-      getGroupFindingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest,
             com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
@@ -421,10 +340,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "GroupFindings"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GroupFindings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -443,30 +359,20 @@ public final class SecurityCenterGrpc {
     return getGroupFindingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.ListAssetsRequest,
-          com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
-      METHOD_LIST_ASSETS = getListAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.ListAssetsRequest,
           com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
       getListAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListAssets",
+      requestType = com.google.cloud.securitycenter.v1beta1.ListAssetsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.ListAssetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.ListAssetsRequest,
           com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
       getListAssetsMethod() {
-    return getListAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.ListAssetsRequest,
-          com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
-      getListAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.ListAssetsRequest,
             com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
@@ -481,9 +387,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "ListAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -501,30 +405,20 @@ public final class SecurityCenterGrpc {
     return getListAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListFindingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.ListFindingsRequest,
-          com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
-      METHOD_LIST_FINDINGS = getListFindingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.ListFindingsRequest,
           com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
       getListFindingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListFindings",
+      requestType = com.google.cloud.securitycenter.v1beta1.ListFindingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.ListFindingsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.ListFindingsRequest,
           com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
       getListFindingsMethod() {
-    return getListFindingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.ListFindingsRequest,
-          com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
-      getListFindingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.ListFindingsRequest,
             com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
@@ -539,9 +433,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "ListFindings"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListFindings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -560,30 +452,20 @@ public final class SecurityCenterGrpc {
     return getListFindingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListSourcesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.ListSourcesRequest,
-          com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
-      METHOD_LIST_SOURCES = getListSourcesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.ListSourcesRequest,
           com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
       getListSourcesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListSources",
+      requestType = com.google.cloud.securitycenter.v1beta1.ListSourcesRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.ListSourcesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.ListSourcesRequest,
           com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
       getListSourcesMethod() {
-    return getListSourcesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.ListSourcesRequest,
-          com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
-      getListSourcesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.ListSourcesRequest,
             com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
@@ -598,9 +480,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "ListSources"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListSources"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -619,30 +499,20 @@ public final class SecurityCenterGrpc {
     return getListSourcesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRunAssetDiscoveryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest,
-          com.google.longrunning.Operation>
-      METHOD_RUN_ASSET_DISCOVERY = getRunAssetDiscoveryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest,
           com.google.longrunning.Operation>
       getRunAssetDiscoveryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RunAssetDiscovery",
+      requestType = com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest,
           com.google.longrunning.Operation>
       getRunAssetDiscoveryMethod() {
-    return getRunAssetDiscoveryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest,
-          com.google.longrunning.Operation>
-      getRunAssetDiscoveryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest,
             com.google.longrunning.Operation>
@@ -657,10 +527,7 @@ public final class SecurityCenterGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "RunAssetDiscovery"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "RunAssetDiscovery"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -678,30 +545,20 @@ public final class SecurityCenterGrpc {
     return getRunAssetDiscoveryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetFindingStateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest,
-          com.google.cloud.securitycenter.v1beta1.Finding>
-      METHOD_SET_FINDING_STATE = getSetFindingStateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest,
           com.google.cloud.securitycenter.v1beta1.Finding>
       getSetFindingStateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetFindingState",
+      requestType = com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest,
           com.google.cloud.securitycenter.v1beta1.Finding>
       getSetFindingStateMethod() {
-    return getSetFindingStateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest,
-          com.google.cloud.securitycenter.v1beta1.Finding>
-      getSetFindingStateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest,
             com.google.cloud.securitycenter.v1beta1.Finding>
@@ -716,10 +573,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "SetFindingState"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetFindingState"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -737,26 +591,18 @@ public final class SecurityCenterGrpc {
     return getSetFindingStateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = SecurityCenterGrpc.getSetIamPolicyMethod) == null) {
@@ -767,9 +613,7 @@ public final class SecurityCenterGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -786,26 +630,18 @@ public final class SecurityCenterGrpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -821,10 +657,7 @@ public final class SecurityCenterGrpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -841,30 +674,20 @@ public final class SecurityCenterGrpc {
     return getTestIamPermissionsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateFindingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest,
-          com.google.cloud.securitycenter.v1beta1.Finding>
-      METHOD_UPDATE_FINDING = getUpdateFindingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest,
           com.google.cloud.securitycenter.v1beta1.Finding>
       getUpdateFindingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateFinding",
+      requestType = com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest,
           com.google.cloud.securitycenter.v1beta1.Finding>
       getUpdateFindingMethod() {
-    return getUpdateFindingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest,
-          com.google.cloud.securitycenter.v1beta1.Finding>
-      getUpdateFindingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest,
             com.google.cloud.securitycenter.v1beta1.Finding>
@@ -879,10 +702,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "UpdateFinding"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateFinding"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -900,30 +720,20 @@ public final class SecurityCenterGrpc {
     return getUpdateFindingMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateOrganizationSettingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
-      METHOD_UPDATE_ORGANIZATION_SETTINGS = getUpdateOrganizationSettingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
       getUpdateOrganizationSettingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateOrganizationSettings",
+      requestType = com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.OrganizationSettings.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
       getUpdateOrganizationSettingsMethod() {
-    return getUpdateOrganizationSettingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
-      getUpdateOrganizationSettingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest,
             com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
@@ -943,9 +753,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "UpdateOrganizationSettings"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateOrganizationSettings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -964,30 +772,20 @@ public final class SecurityCenterGrpc {
     return getUpdateOrganizationSettingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest,
-          com.google.cloud.securitycenter.v1beta1.Source>
-      METHOD_UPDATE_SOURCE = getUpdateSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest,
           com.google.cloud.securitycenter.v1beta1.Source>
       getUpdateSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSource",
+      requestType = com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest,
           com.google.cloud.securitycenter.v1beta1.Source>
       getUpdateSourceMethod() {
-    return getUpdateSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest,
-          com.google.cloud.securitycenter.v1beta1.Source>
-      getUpdateSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest,
             com.google.cloud.securitycenter.v1beta1.Source>
@@ -1002,9 +800,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1beta1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter", "UpdateSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1022,30 +818,20 @@ public final class SecurityCenterGrpc {
     return getUpdateSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSecurityMarksMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest,
-          com.google.cloud.securitycenter.v1beta1.SecurityMarks>
-      METHOD_UPDATE_SECURITY_MARKS = getUpdateSecurityMarksMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest,
           com.google.cloud.securitycenter.v1beta1.SecurityMarks>
       getUpdateSecurityMarksMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSecurityMarks",
+      requestType = com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest.class,
+      responseType = com.google.cloud.securitycenter.v1beta1.SecurityMarks.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest,
           com.google.cloud.securitycenter.v1beta1.SecurityMarks>
       getUpdateSecurityMarksMethod() {
-    return getUpdateSecurityMarksMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest,
-          com.google.cloud.securitycenter.v1beta1.SecurityMarks>
-      getUpdateSecurityMarksMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest,
             com.google.cloud.securitycenter.v1beta1.SecurityMarks>
@@ -1062,9 +848,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1beta1.SecurityCenter",
-                              "UpdateSecurityMarks"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateSecurityMarks"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1085,19 +869,43 @@ public final class SecurityCenterGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SecurityCenterStub newStub(io.grpc.Channel channel) {
-    return new SecurityCenterStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterStub>() {
+          @java.lang.Override
+          public SecurityCenterStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SecurityCenterBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SecurityCenterBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterBlockingStub>() {
+          @java.lang.Override
+          public SecurityCenterBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterBlockingStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SecurityCenterFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SecurityCenterFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterFutureStub>() {
+          @java.lang.Override
+          public SecurityCenterFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterFutureStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1120,7 +928,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.CreateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Source>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateSourceMethod(), responseObserver);
     }
 
     /**
@@ -1135,7 +943,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.CreateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Finding>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateFindingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateFindingMethod(), responseObserver);
     }
 
     /**
@@ -1148,7 +956,7 @@ public final class SecurityCenterGrpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -1162,7 +970,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetOrganizationSettingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetOrganizationSettingsMethod(), responseObserver);
     }
 
     /**
@@ -1176,7 +984,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.GetSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Source>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetSourceMethod(), responseObserver);
     }
 
     /**
@@ -1191,7 +999,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGroupAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGroupAssetsMethod(), responseObserver);
     }
 
     /**
@@ -1208,7 +1016,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGroupFindingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGroupFindingsMethod(), responseObserver);
     }
 
     /**
@@ -1222,7 +1030,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.ListAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListAssetsMethod(), responseObserver);
     }
 
     /**
@@ -1238,7 +1046,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.ListFindingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListFindingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListFindingsMethod(), responseObserver);
     }
 
     /**
@@ -1252,7 +1060,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.ListSourcesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListSourcesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListSourcesMethod(), responseObserver);
     }
 
     /**
@@ -1269,7 +1077,7 @@ public final class SecurityCenterGrpc {
     public void runAssetDiscovery(
         com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getRunAssetDiscoveryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRunAssetDiscoveryMethod(), responseObserver);
     }
 
     /**
@@ -1283,7 +1091,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Finding>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSetFindingStateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetFindingStateMethod(), responseObserver);
     }
 
     /**
@@ -1296,7 +1104,7 @@ public final class SecurityCenterGrpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -1310,7 +1118,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     /**
@@ -1325,7 +1133,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Finding>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateFindingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateFindingMethod(), responseObserver);
     }
 
     /**
@@ -1339,7 +1147,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateOrganizationSettingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateOrganizationSettingsMethod(), responseObserver);
     }
 
     /**
@@ -1353,7 +1161,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Source>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSourceMethod(), responseObserver);
     }
 
     /**
@@ -1367,129 +1175,129 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.SecurityMarks>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSecurityMarksMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSecurityMarksMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateSourceMethodHelper(),
+              getCreateSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.CreateSourceRequest,
                       com.google.cloud.securitycenter.v1beta1.Source>(
                       this, METHODID_CREATE_SOURCE)))
           .addMethod(
-              getCreateFindingMethodHelper(),
+              getCreateFindingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.CreateFindingRequest,
                       com.google.cloud.securitycenter.v1beta1.Finding>(
                       this, METHODID_CREATE_FINDING)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getGetOrganizationSettingsMethodHelper(),
+              getGetOrganizationSettingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest,
                       com.google.cloud.securitycenter.v1beta1.OrganizationSettings>(
                       this, METHODID_GET_ORGANIZATION_SETTINGS)))
           .addMethod(
-              getGetSourceMethodHelper(),
+              getGetSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.GetSourceRequest,
                       com.google.cloud.securitycenter.v1beta1.Source>(this, METHODID_GET_SOURCE)))
           .addMethod(
-              getGroupAssetsMethodHelper(),
+              getGroupAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest,
                       com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>(
                       this, METHODID_GROUP_ASSETS)))
           .addMethod(
-              getGroupFindingsMethodHelper(),
+              getGroupFindingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest,
                       com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>(
                       this, METHODID_GROUP_FINDINGS)))
           .addMethod(
-              getListAssetsMethodHelper(),
+              getListAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.ListAssetsRequest,
                       com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>(
                       this, METHODID_LIST_ASSETS)))
           .addMethod(
-              getListFindingsMethodHelper(),
+              getListFindingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.ListFindingsRequest,
                       com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>(
                       this, METHODID_LIST_FINDINGS)))
           .addMethod(
-              getListSourcesMethodHelper(),
+              getListSourcesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.ListSourcesRequest,
                       com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>(
                       this, METHODID_LIST_SOURCES)))
           .addMethod(
-              getRunAssetDiscoveryMethodHelper(),
+              getRunAssetDiscoveryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest,
                       com.google.longrunning.Operation>(this, METHODID_RUN_ASSET_DISCOVERY)))
           .addMethod(
-              getSetFindingStateMethodHelper(),
+              getSetFindingStateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest,
                       com.google.cloud.securitycenter.v1beta1.Finding>(
                       this, METHODID_SET_FINDING_STATE)))
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
                       com.google.iam.v1.TestIamPermissionsResponse>(
                       this, METHODID_TEST_IAM_PERMISSIONS)))
           .addMethod(
-              getUpdateFindingMethodHelper(),
+              getUpdateFindingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest,
                       com.google.cloud.securitycenter.v1beta1.Finding>(
                       this, METHODID_UPDATE_FINDING)))
           .addMethod(
-              getUpdateOrganizationSettingsMethodHelper(),
+              getUpdateOrganizationSettingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest,
                       com.google.cloud.securitycenter.v1beta1.OrganizationSettings>(
                       this, METHODID_UPDATE_ORGANIZATION_SETTINGS)))
           .addMethod(
-              getUpdateSourceMethodHelper(),
+              getUpdateSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest,
                       com.google.cloud.securitycenter.v1beta1.Source>(
                       this, METHODID_UPDATE_SOURCE)))
           .addMethod(
-              getUpdateSecurityMarksMethodHelper(),
+              getUpdateSecurityMarksMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest,
@@ -1507,11 +1315,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterStub> {
-    private SecurityCenterStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<SecurityCenterStub> {
     private SecurityCenterStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1533,7 +1337,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Source>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateSourceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateSourceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1551,7 +1355,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Finding>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateFindingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateFindingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1567,7 +1371,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1584,7 +1388,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetOrganizationSettingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetOrganizationSettingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1601,9 +1405,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Source>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetSourceMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetSourceMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1619,7 +1421,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGroupAssetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGroupAssetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1639,7 +1441,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGroupFindingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGroupFindingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1656,9 +1458,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListAssetsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListAssetsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1675,7 +1475,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListFindingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListFindingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1692,7 +1492,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListSourcesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListSourcesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1712,7 +1512,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRunAssetDiscoveryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRunAssetDiscoveryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1729,7 +1529,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Finding>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetFindingStateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetFindingStateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1745,7 +1545,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1762,7 +1562,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1780,7 +1580,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Finding>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateFindingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateFindingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1797,7 +1597,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.OrganizationSettings>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateOrganizationSettingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateOrganizationSettingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1814,7 +1614,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.Source>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSourceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSourceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1831,7 +1631,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1beta1.SecurityMarks>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSecurityMarksMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSecurityMarksMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1845,11 +1645,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterBlockingStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterBlockingStub> {
-    private SecurityCenterBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SecurityCenterBlockingStub> {
     private SecurityCenterBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1869,8 +1665,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.Source createSource(
         com.google.cloud.securitycenter.v1beta1.CreateSourceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1883,8 +1678,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.Finding createFinding(
         com.google.cloud.securitycenter.v1beta1.CreateFindingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateFindingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateFindingMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1895,8 +1689,7 @@ public final class SecurityCenterGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1909,7 +1702,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1beta1.OrganizationSettings getOrganizationSettings(
         com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetOrganizationSettingsMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetOrganizationSettingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1921,7 +1714,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.Source getSource(
         com.google.cloud.securitycenter.v1beta1.GetSourceRequest request) {
-      return blockingUnaryCall(getChannel(), getGetSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1934,8 +1727,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse groupAssets(
         com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGroupAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGroupAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1950,8 +1742,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse groupFindings(
         com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGroupFindingsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGroupFindingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1963,8 +1754,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.ListAssetsResponse listAssets(
         com.google.cloud.securitycenter.v1beta1.ListAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1978,8 +1768,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.ListFindingsResponse listFindings(
         com.google.cloud.securitycenter.v1beta1.ListFindingsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListFindingsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListFindingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1991,8 +1780,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.ListSourcesResponse listSources(
         com.google.cloud.securitycenter.v1beta1.ListSourcesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListSourcesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListSourcesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2009,7 +1797,7 @@ public final class SecurityCenterGrpc {
     public com.google.longrunning.Operation runAssetDiscovery(
         com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRunAssetDiscoveryMethodHelper(), getCallOptions(), request);
+          getChannel(), getRunAssetDiscoveryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2021,8 +1809,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.Finding setFindingState(
         com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetFindingStateMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetFindingStateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2033,8 +1820,7 @@ public final class SecurityCenterGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2047,7 +1833,7 @@ public final class SecurityCenterGrpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2060,8 +1846,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.Finding updateFinding(
         com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateFindingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateFindingMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2074,7 +1859,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1beta1.OrganizationSettings updateOrganizationSettings(
         com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateOrganizationSettingsMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateOrganizationSettingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2086,8 +1871,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1beta1.Source updateSource(
         com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2100,7 +1884,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1beta1.SecurityMarks updateSecurityMarks(
         com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateSecurityMarksMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateSecurityMarksMethod(), getCallOptions(), request);
     }
   }
 
@@ -2112,11 +1896,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterFutureStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterFutureStub> {
-    private SecurityCenterFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SecurityCenterFutureStub> {
     private SecurityCenterFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2138,7 +1918,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.Source>
         createSource(com.google.cloud.securitycenter.v1beta1.CreateSourceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateSourceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2153,7 +1933,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.Finding>
         createFinding(com.google.cloud.securitycenter.v1beta1.CreateFindingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateFindingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateFindingMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2166,7 +1946,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2181,8 +1961,7 @@ public final class SecurityCenterGrpc {
         getOrganizationSettings(
             com.google.cloud.securitycenter.v1beta1.GetOrganizationSettingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetOrganizationSettingsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getGetOrganizationSettingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2195,8 +1974,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.securitycenter.v1beta1.Source>
         getSource(com.google.cloud.securitycenter.v1beta1.GetSourceRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetSourceMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2211,7 +1989,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.GroupAssetsResponse>
         groupAssets(com.google.cloud.securitycenter.v1beta1.GroupAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGroupAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGroupAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2228,7 +2006,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.GroupFindingsResponse>
         groupFindings(com.google.cloud.securitycenter.v1beta1.GroupFindingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGroupFindingsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGroupFindingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2242,7 +2020,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.ListAssetsResponse>
         listAssets(com.google.cloud.securitycenter.v1beta1.ListAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2258,7 +2036,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.ListFindingsResponse>
         listFindings(com.google.cloud.securitycenter.v1beta1.ListFindingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListFindingsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListFindingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2272,7 +2050,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.ListSourcesResponse>
         listSources(com.google.cloud.securitycenter.v1beta1.ListSourcesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListSourcesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListSourcesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2290,7 +2068,7 @@ public final class SecurityCenterGrpc {
         runAssetDiscovery(
             com.google.cloud.securitycenter.v1beta1.RunAssetDiscoveryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRunAssetDiscoveryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getRunAssetDiscoveryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2304,7 +2082,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.Finding>
         setFindingState(com.google.cloud.securitycenter.v1beta1.SetFindingStateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetFindingStateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetFindingStateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2317,7 +2095,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2331,7 +2109,7 @@ public final class SecurityCenterGrpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2346,7 +2124,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.Finding>
         updateFinding(com.google.cloud.securitycenter.v1beta1.UpdateFindingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateFindingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateFindingMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2361,8 +2139,7 @@ public final class SecurityCenterGrpc {
         updateOrganizationSettings(
             com.google.cloud.securitycenter.v1beta1.UpdateOrganizationSettingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateOrganizationSettingsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateOrganizationSettingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2376,7 +2153,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1beta1.Source>
         updateSource(com.google.cloud.securitycenter.v1beta1.UpdateSourceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSourceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2391,7 +2168,7 @@ public final class SecurityCenterGrpc {
         updateSecurityMarks(
             com.google.cloud.securitycenter.v1beta1.UpdateSecurityMarksRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSecurityMarksMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateSecurityMarksMethod(), getCallOptions()), request);
     }
   }
 
@@ -2607,24 +2384,24 @@ public final class SecurityCenterGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SecurityCenterFileDescriptorSupplier())
-                      .addMethod(getCreateSourceMethodHelper())
-                      .addMethod(getCreateFindingMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getGetOrganizationSettingsMethodHelper())
-                      .addMethod(getGetSourceMethodHelper())
-                      .addMethod(getGroupAssetsMethodHelper())
-                      .addMethod(getGroupFindingsMethodHelper())
-                      .addMethod(getListAssetsMethodHelper())
-                      .addMethod(getListFindingsMethodHelper())
-                      .addMethod(getListSourcesMethodHelper())
-                      .addMethod(getRunAssetDiscoveryMethodHelper())
-                      .addMethod(getSetFindingStateMethodHelper())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
-                      .addMethod(getUpdateFindingMethodHelper())
-                      .addMethod(getUpdateOrganizationSettingsMethodHelper())
-                      .addMethod(getUpdateSourceMethodHelper())
-                      .addMethod(getUpdateSecurityMarksMethodHelper())
+                      .addMethod(getCreateSourceMethod())
+                      .addMethod(getCreateFindingMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getGetOrganizationSettingsMethod())
+                      .addMethod(getGetSourceMethod())
+                      .addMethod(getGroupAssetsMethod())
+                      .addMethod(getGroupFindingsMethod())
+                      .addMethod(getListAssetsMethod())
+                      .addMethod(getListFindingsMethod())
+                      .addMethod(getListSourcesMethod())
+                      .addMethod(getRunAssetDiscoveryMethod())
+                      .addMethod(getSetFindingStateMethod())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
+                      .addMethod(getUpdateFindingMethod())
+                      .addMethod(getUpdateOrganizationSettingsMethod())
+                      .addMethod(getUpdateSourceMethod())
+                      .addMethod(getUpdateSecurityMarksMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-securitycenter-v1p1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-securitycenter-v1p1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 0.120.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/securitycenter/v1p1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-securitycenter-v1p1beta1/src/main/java/com/google/cloud/securitycenter/v1p1beta1/SecurityCenterGrpc.java
+++ b/grpc-google-cloud-securitycenter-v1p1beta1/src/main/java/com/google/cloud/securitycenter/v1p1beta1/SecurityCenterGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/securitycenter/v1p1beta1/securitycenter_service.proto")
 public final class SecurityCenterGrpc {
 
@@ -39,30 +39,20 @@ public final class SecurityCenterGrpc {
   public static final String SERVICE_NAME = "google.cloud.securitycenter.v1p1beta1.SecurityCenter";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Source>
-      METHOD_CREATE_SOURCE = getCreateSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest,
           com.google.cloud.securitycenter.v1p1beta1.Source>
       getCreateSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateSource",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest,
           com.google.cloud.securitycenter.v1p1beta1.Source>
       getCreateSourceMethod() {
-    return getCreateSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Source>
-      getCreateSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest,
             com.google.cloud.securitycenter.v1p1beta1.Source>
@@ -77,10 +67,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "CreateSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -99,30 +86,20 @@ public final class SecurityCenterGrpc {
     return getCreateSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateFindingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Finding>
-      METHOD_CREATE_FINDING = getCreateFindingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest,
           com.google.cloud.securitycenter.v1p1beta1.Finding>
       getCreateFindingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateFinding",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest,
           com.google.cloud.securitycenter.v1p1beta1.Finding>
       getCreateFindingMethod() {
-    return getCreateFindingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Finding>
-      getCreateFindingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest,
             com.google.cloud.securitycenter.v1p1beta1.Finding>
@@ -137,10 +114,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "CreateFinding"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateFinding"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -159,30 +133,20 @@ public final class SecurityCenterGrpc {
     return getCreateFindingMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
-      METHOD_CREATE_NOTIFICATION_CONFIG = getCreateNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
       getCreateNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.NotificationConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
       getCreateNotificationConfigMethod() {
-    return getCreateNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
-      getCreateNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest,
             com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
@@ -201,9 +165,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "CreateNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "CreateNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -222,30 +184,20 @@ public final class SecurityCenterGrpc {
     return getCreateNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest,
-          com.google.protobuf.Empty>
-      METHOD_DELETE_NOTIFICATION_CONFIG = getDeleteNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest,
           com.google.protobuf.Empty>
       getDeleteNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest,
           com.google.protobuf.Empty>
       getDeleteNotificationConfigMethod() {
-    return getDeleteNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest,
-          com.google.protobuf.Empty>
-      getDeleteNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest,
             com.google.protobuf.Empty>
@@ -264,9 +216,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "DeleteNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "DeleteNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -284,26 +234,18 @@ public final class SecurityCenterGrpc {
     return getDeleteNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_GET_IAM_POLICY = getGetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetIamPolicy",
+      requestType = com.google.iam.v1.GetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       getGetIamPolicyMethod() {
-    return getGetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
-      getGetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
         getGetIamPolicyMethod;
     if ((getGetIamPolicyMethod = SecurityCenterGrpc.getGetIamPolicyMethod) == null) {
@@ -314,10 +256,7 @@ public final class SecurityCenterGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "GetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -334,30 +273,20 @@ public final class SecurityCenterGrpc {
     return getGetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
-      METHOD_GET_NOTIFICATION_CONFIG = getGetNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest,
           com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
       getGetNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.NotificationConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest,
           com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
       getGetNotificationConfigMethod() {
-    return getGetNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
-      getGetNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest,
             com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
@@ -375,9 +304,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "GetNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "GetNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -396,30 +323,20 @@ public final class SecurityCenterGrpc {
     return getGetNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetOrganizationSettingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
-      METHOD_GET_ORGANIZATION_SETTINGS = getGetOrganizationSettingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
       getGetOrganizationSettingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetOrganizationSettings",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
       getGetOrganizationSettingsMethod() {
-    return getGetOrganizationSettingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
-      getGetOrganizationSettingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest,
             com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
@@ -437,9 +354,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "GetOrganizationSettings"))
+                          generateFullMethodName(SERVICE_NAME, "GetOrganizationSettings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -458,30 +373,20 @@ public final class SecurityCenterGrpc {
     return getGetOrganizationSettingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Source>
-      METHOD_GET_SOURCE = getGetSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest,
           com.google.cloud.securitycenter.v1p1beta1.Source>
       getGetSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetSource",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest,
           com.google.cloud.securitycenter.v1p1beta1.Source>
       getGetSourceMethod() {
-    return getGetSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Source>
-      getGetSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest,
             com.google.cloud.securitycenter.v1p1beta1.Source>
@@ -496,9 +401,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter", "GetSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -516,30 +419,20 @@ public final class SecurityCenterGrpc {
     return getGetSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGroupAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
-      METHOD_GROUP_ASSETS = getGroupAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest,
           com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
       getGroupAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GroupAssets",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest,
           com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
       getGroupAssetsMethod() {
-    return getGroupAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
-      getGroupAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest,
             com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
@@ -554,10 +447,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "GroupAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GroupAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -576,30 +466,20 @@ public final class SecurityCenterGrpc {
     return getGroupAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGroupFindingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
-      METHOD_GROUP_FINDINGS = getGroupFindingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
       getGroupFindingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GroupFindings",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
       getGroupFindingsMethod() {
-    return getGroupFindingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
-      getGroupFindingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest,
             com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
@@ -614,10 +494,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "GroupFindings"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GroupFindings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -636,30 +513,20 @@ public final class SecurityCenterGrpc {
     return getGroupFindingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
-      METHOD_LIST_ASSETS = getListAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
       getListAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListAssets",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
       getListAssetsMethod() {
-    return getListAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
-      getListAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest,
             com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
@@ -674,9 +541,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter", "ListAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -694,30 +559,20 @@ public final class SecurityCenterGrpc {
     return getListAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListFindingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
-      METHOD_LIST_FINDINGS = getListFindingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
       getListFindingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListFindings",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
       getListFindingsMethod() {
-    return getListFindingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
-      getListFindingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest,
             com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
@@ -732,10 +587,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "ListFindings"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListFindings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -754,30 +606,21 @@ public final class SecurityCenterGrpc {
     return getListFindingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListNotificationConfigsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
-      METHOD_LIST_NOTIFICATION_CONFIGS = getListNotificationConfigsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
       getListNotificationConfigsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListNotificationConfigs",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest.class,
+      responseType =
+          com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
       getListNotificationConfigsMethod() {
-    return getListNotificationConfigsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
-      getListNotificationConfigsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest,
             com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
@@ -795,9 +638,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "ListNotificationConfigs"))
+                          generateFullMethodName(SERVICE_NAME, "ListNotificationConfigs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -816,30 +657,20 @@ public final class SecurityCenterGrpc {
     return getListNotificationConfigsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListSourcesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
-      METHOD_LIST_SOURCES = getListSourcesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
       getListSourcesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListSources",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest,
           com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
       getListSourcesMethod() {
-    return getListSourcesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest,
-          com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
-      getListSourcesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest,
             com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
@@ -854,10 +685,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "ListSources"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListSources"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -876,30 +704,20 @@ public final class SecurityCenterGrpc {
     return getListSourcesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getRunAssetDiscoveryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest,
-          com.google.longrunning.Operation>
-      METHOD_RUN_ASSET_DISCOVERY = getRunAssetDiscoveryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest,
           com.google.longrunning.Operation>
       getRunAssetDiscoveryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RunAssetDiscovery",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest,
           com.google.longrunning.Operation>
       getRunAssetDiscoveryMethod() {
-    return getRunAssetDiscoveryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest,
-          com.google.longrunning.Operation>
-      getRunAssetDiscoveryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest,
             com.google.longrunning.Operation>
@@ -914,10 +732,7 @@ public final class SecurityCenterGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "RunAssetDiscovery"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "RunAssetDiscovery"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -935,30 +750,20 @@ public final class SecurityCenterGrpc {
     return getRunAssetDiscoveryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetFindingStateMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Finding>
-      METHOD_SET_FINDING_STATE = getSetFindingStateMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest,
           com.google.cloud.securitycenter.v1p1beta1.Finding>
       getSetFindingStateMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetFindingState",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest,
           com.google.cloud.securitycenter.v1p1beta1.Finding>
       getSetFindingStateMethod() {
-    return getSetFindingStateMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Finding>
-      getSetFindingStateMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest,
             com.google.cloud.securitycenter.v1p1beta1.Finding>
@@ -973,10 +778,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "SetFindingState"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetFindingState"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -995,26 +797,18 @@ public final class SecurityCenterGrpc {
     return getSetFindingStateMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSetIamPolicyMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      METHOD_SET_IAM_POLICY = getSetIamPolicyMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SetIamPolicy",
+      requestType = com.google.iam.v1.SetIamPolicyRequest.class,
+      responseType = com.google.iam.v1.Policy.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       getSetIamPolicyMethod() {
-    return getSetIamPolicyMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
-      getSetIamPolicyMethodHelper() {
     io.grpc.MethodDescriptor<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
         getSetIamPolicyMethod;
     if ((getSetIamPolicyMethod = SecurityCenterGrpc.getSetIamPolicyMethod) == null) {
@@ -1025,10 +819,7 @@ public final class SecurityCenterGrpc {
                   io.grpc.MethodDescriptor
                       .<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "SetIamPolicy"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SetIamPolicy"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1045,26 +836,18 @@ public final class SecurityCenterGrpc {
     return getSetIamPolicyMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getTestIamPermissionsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      METHOD_TEST_IAM_PERMISSIONS = getTestIamPermissionsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "TestIamPermissions",
+      requestType = com.google.iam.v1.TestIamPermissionsRequest.class,
+      responseType = com.google.iam.v1.TestIamPermissionsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       getTestIamPermissionsMethod() {
-    return getTestIamPermissionsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
-      getTestIamPermissionsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.iam.v1.TestIamPermissionsRequest,
             com.google.iam.v1.TestIamPermissionsResponse>
@@ -1080,10 +863,7 @@ public final class SecurityCenterGrpc {
                           com.google.iam.v1.TestIamPermissionsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "TestIamPermissions"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "TestIamPermissions"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1100,30 +880,20 @@ public final class SecurityCenterGrpc {
     return getTestIamPermissionsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateFindingMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Finding>
-      METHOD_UPDATE_FINDING = getUpdateFindingMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest,
           com.google.cloud.securitycenter.v1p1beta1.Finding>
       getUpdateFindingMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateFinding",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.Finding.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest,
           com.google.cloud.securitycenter.v1p1beta1.Finding>
       getUpdateFindingMethod() {
-    return getUpdateFindingMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Finding>
-      getUpdateFindingMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest,
             com.google.cloud.securitycenter.v1p1beta1.Finding>
@@ -1138,10 +908,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.Finding>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "UpdateFinding"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateFinding"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1160,30 +927,20 @@ public final class SecurityCenterGrpc {
     return getUpdateFindingMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateNotificationConfigMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
-      METHOD_UPDATE_NOTIFICATION_CONFIG = getUpdateNotificationConfigMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
       getUpdateNotificationConfigMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateNotificationConfig",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.NotificationConfig.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest,
           com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
       getUpdateNotificationConfigMethod() {
-    return getUpdateNotificationConfigMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest,
-          com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
-      getUpdateNotificationConfigMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest,
             com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
@@ -1202,9 +959,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "UpdateNotificationConfig"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateNotificationConfig"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1223,30 +978,21 @@ public final class SecurityCenterGrpc {
     return getUpdateNotificationConfigMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateOrganizationSettingsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
-      METHOD_UPDATE_ORGANIZATION_SETTINGS = getUpdateOrganizationSettingsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
       getUpdateOrganizationSettingsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateOrganizationSettings",
+      requestType =
+          com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest,
           com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
       getUpdateOrganizationSettingsMethod() {
-    return getUpdateOrganizationSettingsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest,
-          com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
-      getUpdateOrganizationSettingsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest,
             com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
@@ -1266,9 +1012,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "UpdateOrganizationSettings"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateOrganizationSettings"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1287,30 +1031,20 @@ public final class SecurityCenterGrpc {
     return getUpdateOrganizationSettingsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSourceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Source>
-      METHOD_UPDATE_SOURCE = getUpdateSourceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest,
           com.google.cloud.securitycenter.v1p1beta1.Source>
       getUpdateSourceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSource",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.Source.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest,
           com.google.cloud.securitycenter.v1p1beta1.Source>
       getUpdateSourceMethod() {
-    return getUpdateSourceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest,
-          com.google.cloud.securitycenter.v1p1beta1.Source>
-      getUpdateSourceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest,
             com.google.cloud.securitycenter.v1p1beta1.Source>
@@ -1325,10 +1059,7 @@ public final class SecurityCenterGrpc {
                           com.google.cloud.securitycenter.v1p1beta1.Source>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "UpdateSource"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateSource"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1347,30 +1078,20 @@ public final class SecurityCenterGrpc {
     return getUpdateSourceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateSecurityMarksMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest,
-          com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
-      METHOD_UPDATE_SECURITY_MARKS = getUpdateSecurityMarksMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest,
           com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
       getUpdateSecurityMarksMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateSecurityMarks",
+      requestType = com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest.class,
+      responseType = com.google.cloud.securitycenter.v1p1beta1.SecurityMarks.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest,
           com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
       getUpdateSecurityMarksMethod() {
-    return getUpdateSecurityMarksMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest,
-          com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
-      getUpdateSecurityMarksMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest,
             com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
@@ -1387,9 +1108,7 @@ public final class SecurityCenterGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.securitycenter.v1p1beta1.SecurityCenter",
-                              "UpdateSecurityMarks"))
+                          generateFullMethodName(SERVICE_NAME, "UpdateSecurityMarks"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1410,19 +1129,43 @@ public final class SecurityCenterGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static SecurityCenterStub newStub(io.grpc.Channel channel) {
-    return new SecurityCenterStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterStub>() {
+          @java.lang.Override
+          public SecurityCenterStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static SecurityCenterBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new SecurityCenterBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterBlockingStub>() {
+          @java.lang.Override
+          public SecurityCenterBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterBlockingStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static SecurityCenterFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new SecurityCenterFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<SecurityCenterFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<SecurityCenterFutureStub>() {
+          @java.lang.Override
+          public SecurityCenterFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new SecurityCenterFutureStub(channel, callOptions);
+          }
+        };
+    return SecurityCenterFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -1445,7 +1188,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Source>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateSourceMethod(), responseObserver);
     }
 
     /**
@@ -1460,7 +1203,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Finding>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateFindingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateFindingMethod(), responseObserver);
     }
 
     /**
@@ -1474,7 +1217,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1487,7 +1230,7 @@ public final class SecurityCenterGrpc {
     public void deleteNotificationConfig(
         com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1500,7 +1243,7 @@ public final class SecurityCenterGrpc {
     public void getIamPolicy(
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -1514,7 +1257,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1528,7 +1271,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetOrganizationSettingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetOrganizationSettingsMethod(), responseObserver);
     }
 
     /**
@@ -1542,7 +1285,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Source>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetSourceMethod(), responseObserver);
     }
 
     /**
@@ -1557,7 +1300,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGroupAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGroupAssetsMethod(), responseObserver);
     }
 
     /**
@@ -1574,7 +1317,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGroupFindingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGroupFindingsMethod(), responseObserver);
     }
 
     /**
@@ -1588,7 +1331,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListAssetsMethod(), responseObserver);
     }
 
     /**
@@ -1604,7 +1347,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListFindingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListFindingsMethod(), responseObserver);
     }
 
     /**
@@ -1619,7 +1362,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListNotificationConfigsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListNotificationConfigsMethod(), responseObserver);
     }
 
     /**
@@ -1633,7 +1376,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListSourcesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListSourcesMethod(), responseObserver);
     }
 
     /**
@@ -1650,7 +1393,7 @@ public final class SecurityCenterGrpc {
     public void runAssetDiscovery(
         com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getRunAssetDiscoveryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getRunAssetDiscoveryMethod(), responseObserver);
     }
 
     /**
@@ -1664,7 +1407,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Finding>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSetFindingStateMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetFindingStateMethod(), responseObserver);
     }
 
     /**
@@ -1677,7 +1420,7 @@ public final class SecurityCenterGrpc {
     public void setIamPolicy(
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
-      asyncUnimplementedUnaryCall(getSetIamPolicyMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSetIamPolicyMethod(), responseObserver);
     }
 
     /**
@@ -1691,7 +1434,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.TestIamPermissionsRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getTestIamPermissionsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getTestIamPermissionsMethod(), responseObserver);
     }
 
     /**
@@ -1706,7 +1449,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Finding>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateFindingMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateFindingMethod(), responseObserver);
     }
 
     /**
@@ -1720,7 +1463,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateNotificationConfigMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateNotificationConfigMethod(), responseObserver);
     }
 
     /**
@@ -1734,7 +1477,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateOrganizationSettingsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateOrganizationSettingsMethod(), responseObserver);
     }
 
     /**
@@ -1748,7 +1491,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Source>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSourceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSourceMethod(), responseObserver);
     }
 
     /**
@@ -1762,163 +1505,163 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateSecurityMarksMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateSecurityMarksMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateSourceMethodHelper(),
+              getCreateSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest,
                       com.google.cloud.securitycenter.v1p1beta1.Source>(
                       this, METHODID_CREATE_SOURCE)))
           .addMethod(
-              getCreateFindingMethodHelper(),
+              getCreateFindingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest,
                       com.google.cloud.securitycenter.v1p1beta1.Finding>(
                       this, METHODID_CREATE_FINDING)))
           .addMethod(
-              getCreateNotificationConfigMethodHelper(),
+              getCreateNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest,
                       com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>(
                       this, METHODID_CREATE_NOTIFICATION_CONFIG)))
           .addMethod(
-              getDeleteNotificationConfigMethodHelper(),
+              getDeleteNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest,
                       com.google.protobuf.Empty>(this, METHODID_DELETE_NOTIFICATION_CONFIG)))
           .addMethod(
-              getGetIamPolicyMethodHelper(),
+              getGetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_GET_IAM_POLICY)))
           .addMethod(
-              getGetNotificationConfigMethodHelper(),
+              getGetNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest,
                       com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>(
                       this, METHODID_GET_NOTIFICATION_CONFIG)))
           .addMethod(
-              getGetOrganizationSettingsMethodHelper(),
+              getGetOrganizationSettingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>(
                       this, METHODID_GET_ORGANIZATION_SETTINGS)))
           .addMethod(
-              getGetSourceMethodHelper(),
+              getGetSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest,
                       com.google.cloud.securitycenter.v1p1beta1.Source>(this, METHODID_GET_SOURCE)))
           .addMethod(
-              getGroupAssetsMethodHelper(),
+              getGroupAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>(
                       this, METHODID_GROUP_ASSETS)))
           .addMethod(
-              getGroupFindingsMethodHelper(),
+              getGroupFindingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>(
                       this, METHODID_GROUP_FINDINGS)))
           .addMethod(
-              getListAssetsMethodHelper(),
+              getListAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>(
                       this, METHODID_LIST_ASSETS)))
           .addMethod(
-              getListFindingsMethodHelper(),
+              getListFindingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>(
                       this, METHODID_LIST_FINDINGS)))
           .addMethod(
-              getListNotificationConfigsMethodHelper(),
+              getListNotificationConfigsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>(
                       this, METHODID_LIST_NOTIFICATION_CONFIGS)))
           .addMethod(
-              getListSourcesMethodHelper(),
+              getListSourcesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest,
                       com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>(
                       this, METHODID_LIST_SOURCES)))
           .addMethod(
-              getRunAssetDiscoveryMethodHelper(),
+              getRunAssetDiscoveryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest,
                       com.google.longrunning.Operation>(this, METHODID_RUN_ASSET_DISCOVERY)))
           .addMethod(
-              getSetFindingStateMethodHelper(),
+              getSetFindingStateMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest,
                       com.google.cloud.securitycenter.v1p1beta1.Finding>(
                       this, METHODID_SET_FINDING_STATE)))
           .addMethod(
-              getSetIamPolicyMethodHelper(),
+              getSetIamPolicyMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>(
                       this, METHODID_SET_IAM_POLICY)))
           .addMethod(
-              getTestIamPermissionsMethodHelper(),
+              getTestIamPermissionsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.iam.v1.TestIamPermissionsRequest,
                       com.google.iam.v1.TestIamPermissionsResponse>(
                       this, METHODID_TEST_IAM_PERMISSIONS)))
           .addMethod(
-              getUpdateFindingMethodHelper(),
+              getUpdateFindingMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest,
                       com.google.cloud.securitycenter.v1p1beta1.Finding>(
                       this, METHODID_UPDATE_FINDING)))
           .addMethod(
-              getUpdateNotificationConfigMethodHelper(),
+              getUpdateNotificationConfigMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest,
                       com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>(
                       this, METHODID_UPDATE_NOTIFICATION_CONFIG)))
           .addMethod(
-              getUpdateOrganizationSettingsMethodHelper(),
+              getUpdateOrganizationSettingsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest,
                       com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>(
                       this, METHODID_UPDATE_ORGANIZATION_SETTINGS)))
           .addMethod(
-              getUpdateSourceMethodHelper(),
+              getUpdateSourceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest,
                       com.google.cloud.securitycenter.v1p1beta1.Source>(
                       this, METHODID_UPDATE_SOURCE)))
           .addMethod(
-              getUpdateSecurityMarksMethodHelper(),
+              getUpdateSecurityMarksMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest,
@@ -1936,11 +1679,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterStub> {
-    private SecurityCenterStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractAsyncStub<SecurityCenterStub> {
     private SecurityCenterStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1962,7 +1701,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Source>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateSourceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateSourceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1980,7 +1719,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Finding>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateFindingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateFindingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1997,7 +1736,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2013,7 +1752,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2029,7 +1768,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.GetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2046,7 +1785,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2063,7 +1802,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetOrganizationSettingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetOrganizationSettingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2080,9 +1819,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Source>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetSourceMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetSourceMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2098,7 +1835,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGroupAssetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGroupAssetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2118,7 +1855,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGroupFindingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGroupFindingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2135,9 +1872,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListAssetsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListAssetsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2154,7 +1889,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListFindingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListFindingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2172,7 +1907,7 @@ public final class SecurityCenterGrpc {
                 com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListNotificationConfigsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListNotificationConfigsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2189,7 +1924,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListSourcesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListSourcesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2209,7 +1944,7 @@ public final class SecurityCenterGrpc {
         com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getRunAssetDiscoveryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getRunAssetDiscoveryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2226,7 +1961,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Finding>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetFindingStateMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetFindingStateMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2242,7 +1977,7 @@ public final class SecurityCenterGrpc {
         com.google.iam.v1.SetIamPolicyRequest request,
         io.grpc.stub.StreamObserver<com.google.iam.v1.Policy> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2259,7 +1994,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.iam.v1.TestIamPermissionsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2277,7 +2012,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Finding>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateFindingMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateFindingMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2294,7 +2029,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.NotificationConfig>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateNotificationConfigMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateNotificationConfigMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2311,7 +2046,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateOrganizationSettingsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateOrganizationSettingsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2328,7 +2063,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.Source>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSourceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSourceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2345,7 +2080,7 @@ public final class SecurityCenterGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.securitycenter.v1p1beta1.SecurityMarks>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateSecurityMarksMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateSecurityMarksMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2359,11 +2094,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterBlockingStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterBlockingStub> {
-    private SecurityCenterBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<SecurityCenterBlockingStub> {
     private SecurityCenterBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2383,8 +2114,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.Source createSource(
         com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2397,8 +2127,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.Finding createFinding(
         com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateFindingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateFindingMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2411,7 +2140,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1p1beta1.NotificationConfig createNotificationConfig(
         com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getCreateNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getCreateNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2424,7 +2153,7 @@ public final class SecurityCenterGrpc {
     public com.google.protobuf.Empty deleteNotificationConfig(
         com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getDeleteNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getDeleteNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2435,8 +2164,7 @@ public final class SecurityCenterGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2449,7 +2177,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1p1beta1.NotificationConfig getNotificationConfig(
         com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2462,7 +2190,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1p1beta1.OrganizationSettings getOrganizationSettings(
         com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetOrganizationSettingsMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetOrganizationSettingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2474,7 +2202,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.Source getSource(
         com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest request) {
-      return blockingUnaryCall(getChannel(), getGetSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2487,8 +2215,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse groupAssets(
         com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGroupAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGroupAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2503,8 +2230,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse groupFindings(
         com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGroupFindingsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGroupFindingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2516,8 +2242,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse listAssets(
         com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2531,8 +2256,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse listFindings(
         com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListFindingsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListFindingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2546,7 +2270,7 @@ public final class SecurityCenterGrpc {
         listNotificationConfigs(
             com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListNotificationConfigsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListNotificationConfigsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2558,8 +2282,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse listSources(
         com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListSourcesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListSourcesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2576,7 +2299,7 @@ public final class SecurityCenterGrpc {
     public com.google.longrunning.Operation runAssetDiscovery(
         com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest request) {
       return blockingUnaryCall(
-          getChannel(), getRunAssetDiscoveryMethodHelper(), getCallOptions(), request);
+          getChannel(), getRunAssetDiscoveryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2588,8 +2311,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.Finding setFindingState(
         com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetFindingStateMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetFindingStateMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2600,8 +2322,7 @@ public final class SecurityCenterGrpc {
      * </pre>
      */
     public com.google.iam.v1.Policy setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getSetIamPolicyMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getSetIamPolicyMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2614,7 +2335,7 @@ public final class SecurityCenterGrpc {
     public com.google.iam.v1.TestIamPermissionsResponse testIamPermissions(
         com.google.iam.v1.TestIamPermissionsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getTestIamPermissionsMethodHelper(), getCallOptions(), request);
+          getChannel(), getTestIamPermissionsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2627,8 +2348,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.Finding updateFinding(
         com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateFindingMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateFindingMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2641,7 +2361,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1p1beta1.NotificationConfig updateNotificationConfig(
         com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateNotificationConfigMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateNotificationConfigMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2655,7 +2375,7 @@ public final class SecurityCenterGrpc {
         updateOrganizationSettings(
             com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateOrganizationSettingsMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateOrganizationSettingsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2667,8 +2387,7 @@ public final class SecurityCenterGrpc {
      */
     public com.google.cloud.securitycenter.v1p1beta1.Source updateSource(
         com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateSourceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateSourceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2681,7 +2400,7 @@ public final class SecurityCenterGrpc {
     public com.google.cloud.securitycenter.v1p1beta1.SecurityMarks updateSecurityMarks(
         com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateSecurityMarksMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateSecurityMarksMethod(), getCallOptions(), request);
     }
   }
 
@@ -2693,11 +2412,7 @@ public final class SecurityCenterGrpc {
    * </pre>
    */
   public static final class SecurityCenterFutureStub
-      extends io.grpc.stub.AbstractStub<SecurityCenterFutureStub> {
-    private SecurityCenterFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<SecurityCenterFutureStub> {
     private SecurityCenterFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -2719,7 +2434,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.Source>
         createSource(com.google.cloud.securitycenter.v1p1beta1.CreateSourceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateSourceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2734,7 +2449,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.Finding>
         createFinding(com.google.cloud.securitycenter.v1p1beta1.CreateFindingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateFindingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateFindingMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2749,8 +2464,7 @@ public final class SecurityCenterGrpc {
         createNotificationConfig(
             com.google.cloud.securitycenter.v1p1beta1.CreateNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateNotificationConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getCreateNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2764,8 +2478,7 @@ public final class SecurityCenterGrpc {
         deleteNotificationConfig(
             com.google.cloud.securitycenter.v1p1beta1.DeleteNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteNotificationConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getDeleteNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2778,7 +2491,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         getIamPolicy(com.google.iam.v1.GetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2793,7 +2506,7 @@ public final class SecurityCenterGrpc {
         getNotificationConfig(
             com.google.cloud.securitycenter.v1p1beta1.GetNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetNotificationConfigMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2808,8 +2521,7 @@ public final class SecurityCenterGrpc {
         getOrganizationSettings(
             com.google.cloud.securitycenter.v1p1beta1.GetOrganizationSettingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetOrganizationSettingsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getGetOrganizationSettingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2822,8 +2534,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.securitycenter.v1p1beta1.Source>
         getSource(com.google.cloud.securitycenter.v1p1beta1.GetSourceRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetSourceMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2838,7 +2549,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.GroupAssetsResponse>
         groupAssets(com.google.cloud.securitycenter.v1p1beta1.GroupAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGroupAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGroupAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2855,7 +2566,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.GroupFindingsResponse>
         groupFindings(com.google.cloud.securitycenter.v1p1beta1.GroupFindingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGroupFindingsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGroupFindingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2869,7 +2580,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.ListAssetsResponse>
         listAssets(com.google.cloud.securitycenter.v1p1beta1.ListAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2885,7 +2596,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.ListFindingsResponse>
         listFindings(com.google.cloud.securitycenter.v1p1beta1.ListFindingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListFindingsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListFindingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2900,8 +2611,7 @@ public final class SecurityCenterGrpc {
         listNotificationConfigs(
             com.google.cloud.securitycenter.v1p1beta1.ListNotificationConfigsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListNotificationConfigsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getListNotificationConfigsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2915,7 +2625,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.ListSourcesResponse>
         listSources(com.google.cloud.securitycenter.v1p1beta1.ListSourcesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListSourcesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListSourcesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2933,7 +2643,7 @@ public final class SecurityCenterGrpc {
         runAssetDiscovery(
             com.google.cloud.securitycenter.v1p1beta1.RunAssetDiscoveryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getRunAssetDiscoveryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getRunAssetDiscoveryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2947,7 +2657,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.Finding>
         setFindingState(com.google.cloud.securitycenter.v1p1beta1.SetFindingStateRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetFindingStateMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetFindingStateMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2960,7 +2670,7 @@ public final class SecurityCenterGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.iam.v1.Policy>
         setIamPolicy(com.google.iam.v1.SetIamPolicyRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSetIamPolicyMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSetIamPolicyMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2974,7 +2684,7 @@ public final class SecurityCenterGrpc {
             com.google.iam.v1.TestIamPermissionsResponse>
         testIamPermissions(com.google.iam.v1.TestIamPermissionsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getTestIamPermissionsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getTestIamPermissionsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2989,7 +2699,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.Finding>
         updateFinding(com.google.cloud.securitycenter.v1p1beta1.UpdateFindingRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateFindingMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateFindingMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3004,8 +2714,7 @@ public final class SecurityCenterGrpc {
         updateNotificationConfig(
             com.google.cloud.securitycenter.v1p1beta1.UpdateNotificationConfigRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateNotificationConfigMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateNotificationConfigMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3020,8 +2729,7 @@ public final class SecurityCenterGrpc {
         updateOrganizationSettings(
             com.google.cloud.securitycenter.v1p1beta1.UpdateOrganizationSettingsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateOrganizationSettingsMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getUpdateOrganizationSettingsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3035,7 +2743,7 @@ public final class SecurityCenterGrpc {
             com.google.cloud.securitycenter.v1p1beta1.Source>
         updateSource(com.google.cloud.securitycenter.v1p1beta1.UpdateSourceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSourceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateSourceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3050,7 +2758,7 @@ public final class SecurityCenterGrpc {
         updateSecurityMarks(
             com.google.cloud.securitycenter.v1p1beta1.UpdateSecurityMarksRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateSecurityMarksMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateSecurityMarksMethod(), getCallOptions()), request);
     }
   }
 
@@ -3304,29 +3012,29 @@ public final class SecurityCenterGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new SecurityCenterFileDescriptorSupplier())
-                      .addMethod(getCreateSourceMethodHelper())
-                      .addMethod(getCreateFindingMethodHelper())
-                      .addMethod(getCreateNotificationConfigMethodHelper())
-                      .addMethod(getDeleteNotificationConfigMethodHelper())
-                      .addMethod(getGetIamPolicyMethodHelper())
-                      .addMethod(getGetNotificationConfigMethodHelper())
-                      .addMethod(getGetOrganizationSettingsMethodHelper())
-                      .addMethod(getGetSourceMethodHelper())
-                      .addMethod(getGroupAssetsMethodHelper())
-                      .addMethod(getGroupFindingsMethodHelper())
-                      .addMethod(getListAssetsMethodHelper())
-                      .addMethod(getListFindingsMethodHelper())
-                      .addMethod(getListNotificationConfigsMethodHelper())
-                      .addMethod(getListSourcesMethodHelper())
-                      .addMethod(getRunAssetDiscoveryMethodHelper())
-                      .addMethod(getSetFindingStateMethodHelper())
-                      .addMethod(getSetIamPolicyMethodHelper())
-                      .addMethod(getTestIamPermissionsMethodHelper())
-                      .addMethod(getUpdateFindingMethodHelper())
-                      .addMethod(getUpdateNotificationConfigMethodHelper())
-                      .addMethod(getUpdateOrganizationSettingsMethodHelper())
-                      .addMethod(getUpdateSourceMethodHelper())
-                      .addMethod(getUpdateSecurityMarksMethodHelper())
+                      .addMethod(getCreateSourceMethod())
+                      .addMethod(getCreateFindingMethod())
+                      .addMethod(getCreateNotificationConfigMethod())
+                      .addMethod(getDeleteNotificationConfigMethod())
+                      .addMethod(getGetIamPolicyMethod())
+                      .addMethod(getGetNotificationConfigMethod())
+                      .addMethod(getGetOrganizationSettingsMethod())
+                      .addMethod(getGetSourceMethod())
+                      .addMethod(getGroupAssetsMethod())
+                      .addMethod(getGroupFindingsMethod())
+                      .addMethod(getListAssetsMethod())
+                      .addMethod(getListFindingsMethod())
+                      .addMethod(getListNotificationConfigsMethod())
+                      .addMethod(getListSourcesMethod())
+                      .addMethod(getRunAssetDiscoveryMethod())
+                      .addMethod(getSetFindingStateMethod())
+                      .addMethod(getSetIamPolicyMethod())
+                      .addMethod(getTestIamPermissionsMethod())
+                      .addMethod(getUpdateFindingMethod())
+                      .addMethod(getUpdateNotificationConfigMethod())
+                      .addMethod(getUpdateOrganizationSettingsMethod())
+                      .addMethod(getUpdateSourceMethod())
+                      .addMethod(getUpdateSecurityMarksMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,22 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'securitycenter'
 versions = ['v1p1beta1', 'v1beta1', 'v1']
-config_pattern = '/google/cloud/securitycenter/artman_securitycenter_{version}.yaml'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern=config_pattern,
-    gapic=gapic,
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

