### PR TITLE
docs: Wrap samples with future prefix

### DIFF
--- a/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/CreateNotificationConfigSnippets.java
+++ b/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/CreateNotificationConfigSnippets.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.examples.securitycenter.snippets;
 
+// [START securitycenter_create_notification_config]
 // [START scc_create_notification_config]
 import com.google.cloud.securitycenter.v1.CreateNotificationConfigRequest;
 import com.google.cloud.securitycenter.v1.NotificationConfig;
@@ -23,11 +24,13 @@ import com.google.cloud.securitycenter.v1.NotificationConfig.StreamingConfig;
 import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import java.io.IOException;
 // [END scc_create_notification_config]
+// [END securitycenter_create_notification_config]
 
 /** Create NotificationConfig Snippet. */
 final class CreateNotificationConfigSnippets {
   private CreateNotificationConfigSnippets() {}
 
+  // [START securitycenter_create_notification_config]
   // [START scc_create_notification_config]
   public static NotificationConfig createNotificationConfig(
       String organizationId, String notificationConfigId, String projectId, String topicName)
@@ -62,4 +65,5 @@ final class CreateNotificationConfigSnippets {
     }
   }
   // [END scc_create_notification_config]
+  // [END securitycenter_create_notification_config]
 }

--- a/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/DeleteNotificationConfigSnippets.java
+++ b/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/DeleteNotificationConfigSnippets.java
@@ -16,11 +16,13 @@
 
 package com.google.cloud.examples.securitycenter.snippets;
 
+// [START securitycenter_delete_notification_config]
 // [START scc_delete_notification_config]
 import com.google.cloud.securitycenter.v1.NotificationConfigName;
 import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import java.io.IOException;
 // [END scc_delete_notification_config]
+// [END securitycenter_delete_notification_config]
 
 /** Snippets for how to Delete NotificationConfigs. */
 final class DeleteNotificationConfigSnippets {

--- a/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/GetNotificationConfigSnippets.java
+++ b/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/GetNotificationConfigSnippets.java
@@ -16,17 +16,20 @@
 
 package com.google.cloud.examples.securitycenter.snippets;
 
+// [START securitycenter_get_notification_config]
 // [START scc_get_notification_config]
 import com.google.cloud.securitycenter.v1.NotificationConfig;
 import com.google.cloud.securitycenter.v1.NotificationConfigName;
 import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import java.io.IOException;
 // [END scc_get_notification_config]
+// [END securitycenter_get_notification_config]
 
 /** Snippets for how to GetNotificationConfig. */
 final class GetNotificationConfigSnippets {
   private GetNotificationConfigSnippets() {}
 
+  // [START securitycenter_get_notification_config]
   // [START scc_get_notification_config]
   public static NotificationConfig getNotificationConfig(
       String organizationId, String notificationConfigId) throws IOException {
@@ -47,4 +50,5 @@ final class GetNotificationConfigSnippets {
     }
   }
   // [END scc_get_notification_config]
+  // [END securitycenter_get_notification_config]
 }

--- a/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/ListNotificationConfigSnippets.java
+++ b/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/ListNotificationConfigSnippets.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.examples.securitycenter.snippets;
 
+// [START securitycenter_list_notification_configs]
 // [START scc_list_notification_configs]
 import com.google.cloud.securitycenter.v1.NotificationConfig;
 import com.google.cloud.securitycenter.v1.OrganizationName;
@@ -24,11 +25,13 @@ import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListNotificationC
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 // [END scc_list_notification_configs]
+// [END securitycenter_list_notification_configs]
 
 /** Snippets for how to ListNotificationConfig. */
 final class ListNotificationConfigSnippets {
   private ListNotificationConfigSnippets() {}
 
+  // [START securitycenter_list_notification_configs]
   // [START scc_list_notification_configs]
   public static ImmutableList<NotificationConfig> listNotificationConfigs(String organizationId)
       throws IOException {
@@ -48,5 +51,6 @@ final class ListNotificationConfigSnippets {
     }
   }
   // [END scc_list_notification_configs]
+  // [END securitycenter_list_notification_configs]
 
 }

--- a/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/NotificationReceiver.java
+++ b/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/NotificationReceiver.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.examples.securitycenter.snippets;
 
+// [START securitycenter_receive_notifications]
 // [START scc_receive_notifications]
 
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
@@ -73,3 +74,4 @@ public class NotificationReceiver {
   }
 }
 // [END scc_receive_notifications]
+// [END securitycenter_receive_notifications]

--- a/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/UpdateNotificationConfigSnippets.java
+++ b/samples/snippets/src/main/java/com/google/cloud/examples/securitycenter/snippets/UpdateNotificationConfigSnippets.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.examples.securitycenter.snippets;
 
+// [START securitycenter_update_notification_config]
 // [START scc_update_notification_config]
 import com.google.cloud.securitycenter.v1.NotificationConfig;
 import com.google.cloud.securitycenter.v1.NotificationConfig.StreamingConfig;
@@ -23,11 +24,13 @@ import com.google.cloud.securitycenter.v1.SecurityCenterClient;
 import com.google.protobuf.FieldMask;
 import java.io.IOException;
 // [END scc_update_notification_config]
+// [END securitycenter_update_notification_config]
 
 /** Snippets for UpdateNotificationConfig. */
 final class UpdateNotificationConfigSnippets {
   private UpdateNotificationConfigSnippets() {}
 
+  // [START securitycenter_update_notification_config]
   // [START scc_update_notification_config]
   public static NotificationConfig updateNotificationConfig(
       String organizationId, String notificationConfigId, String projectId, String topicName)
@@ -65,4 +68,5 @@ final class UpdateNotificationConfigSnippets {
     }
   }
   // [END scc_update_notification_config]
+  // [END securitycenter_update_notification_config]
 }


### PR DESCRIPTION
Standardizing Security Command Center samples to use 'securitycenter' prefixing. 

- Wrapped existing samples to keep published doclinks unbroken
- Replace region tags that aren't published. 

Once this PR is through, published sample inclusions will be updated to use the new prefix, then I'll come through again and remove the unused block wraps.

